### PR TITLE
EJson language

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+/bower_components/
+/node_modules/
+/.pulp-cache/
+/output/
+/.psci*
+/src/.webpack.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+language: node_js
+dist: trusty
+sudo: required
+node_js:
+  - 5
+install:
+  - npm install pulp bower -g
+  - npm install && bower install
+script:
+  - pulp build # todo: add tests
+
+after_success:
+  - >-
+    test $TRAVIS_TAG &&
+    psc-publish > .pursuit.json &&
+    curl -X POST http://pursuit.purescript.org/packages \
+      -d @.pursuit.json \
+      -H 'Accept: application/json' \
+      -H "Authorization: token ${GITHUB_TOKEN}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ install:
   - npm install pulp bower -g
   - npm install && bower install
 script:
-  - pulp build # todo: add tests
+  - pulp test
 
 after_success:
   - >-

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,21 @@
+{
+  "name": "purescript-ejson",
+  "version": "0.1.0",
+  "moduleType": [
+    "node"
+  ],
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "output"
+  ],
+  "dependencies": {
+    "purescript-argonaut-codecs": "^0.6.1",
+    "purescript-argonaut-core": "^0.2.3",
+    "purescript-fixed-points": "^0.1.0",
+    "purescript-hugenums": "^1.3.1",
+    "purescript-maps": "^0.5.7",
+    "purescript-strongcheck": "^0.14.7"
+  }
+}

--- a/bower.json
+++ b/bower.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "purescript-argonaut-codecs": "^0.6.1",
     "purescript-argonaut-core": "^0.2.3",
+    "purescript-bifunctors": "^0.4.0",
     "purescript-fixed-points": "^0.1.0",
     "purescript-hugenums": "^1.3.1",
     "purescript-maps": "^0.5.7",

--- a/package.json
+++ b/package.json
@@ -1,0 +1,6 @@
+{
+  "private": true,
+  "devDependencies": {
+    "purescript": "^0.8.2"
+  }
+}

--- a/src/Data/Json/Extended.purs
+++ b/src/Data/Json/Extended.purs
@@ -84,7 +84,7 @@ instance showEJson ∷ Show EJson where
 
 instance decodeJsonEJson ∷ DecodeJson EJson where
   decodeJson json =
-    map roll $
+    roll <$>
       Sig.decodeJsonEJsonF
         decodeJson
         (Sig.String >>> roll)

--- a/src/Data/Json/Extended.purs
+++ b/src/Data/Json/Extended.purs
@@ -15,6 +15,7 @@ module Data.Json.Extended
 
 import Prelude
 
+import Data.Eq1 (eq1)
 import Data.Argonaut.Core as JS
 import Data.Argonaut.Encode (class EncodeJson)
 import Data.Argonaut.Decode (class DecodeJson)
@@ -39,6 +40,10 @@ getEJson (EJson x) = x
 instance ejsonViewEJson ∷ EJsonView EJson where
   intoEJson = EJson <<< Mu.roll <<< map getEJson
   outEJson = getEJson >>> Mu.unroll >>> map EJson >>> E.Right
+
+instance eqEJson ∷ Eq EJson where
+  eq (EJson a) (EJson b) =
+    eq1 (Mu.unroll a) (Mu.unroll b)
 
 instance showEJson ∷ Show EJson where
   show = renderEJson

--- a/src/Data/Json/Extended.purs
+++ b/src/Data/Json/Extended.purs
@@ -6,6 +6,21 @@ module Data.Json.Extended
   , roll
   , unroll
 
+  , null
+  , boolean
+  , integer
+  , decimal
+  , string
+  , timestamp
+  , date
+  , time
+  , interval
+  , objectId
+  , orderedSet
+  , object
+  , object'
+  , array
+
   , renderEJson
 
   , arbitraryEJsonOfSize
@@ -15,11 +30,17 @@ module Data.Json.Extended
 import Prelude
 
 import Data.Eq1 (eq1)
+import Data.Ord1 (compare1)
 import Data.Argonaut.Encode (class EncodeJson, encodeJson)
 import Data.Argonaut.Decode (class DecodeJson, decodeJson)
 
 import Data.Functor.Mu as Mu
+import Data.HugeNum as HN
+import Data.List as L
+import Data.Map as Map
 import Data.Maybe as M
+import Data.StrMap as SM
+import Data.Tuple as T
 
 import Test.StrongCheck as SC
 import Test.StrongCheck.Gen as Gen
@@ -53,6 +74,10 @@ unroll =
 instance eqEJson ∷ Eq EJson where
   eq (EJson a) (EJson b) =
     eq1 (Mu.unroll a) (Mu.unroll b)
+
+instance ordEJson ∷ Ord EJson where
+  compare (EJson a) (EJson b) =
+    compare1 (Mu.unroll a) (Mu.unroll b)
 
 instance showEJson ∷ Show EJson where
   show = renderEJson
@@ -115,3 +140,46 @@ renderEJson (EJson x) =
     renderEJson
     (EJson <$> Mu.unroll x)
 
+null ∷ EJson
+null = roll Sig.Null
+
+boolean ∷ Boolean → EJson
+boolean = roll <<< Sig.Boolean
+
+integer ∷ Int → EJson
+integer = roll <<< Sig.Integer
+
+decimal ∷ HN.HugeNum → EJson
+decimal = roll <<< Sig.Decimal
+
+string ∷ String → EJson
+string = roll <<< Sig.String
+
+timestamp ∷ String → EJson
+timestamp = roll <<< Sig.Timestamp
+
+date ∷ String → EJson
+date = roll <<< Sig.Date
+
+time ∷ String → EJson
+time = roll <<< Sig.Time
+
+interval ∷ String → EJson
+interval = roll <<< Sig.Interval
+
+objectId ∷ String → EJson
+objectId = roll <<< Sig.ObjectId
+
+orderedSet ∷ Array EJson → EJson
+orderedSet = roll <<< Sig.OrderedSet
+
+array ∷ Array EJson → EJson
+array = roll <<< Sig.Array
+
+object ∷ Map.Map EJson EJson → EJson
+object = roll <<< Sig.Object <<< L.fromList <<< Map.toList
+
+object' ∷ SM.StrMap EJson → EJson
+object' = roll <<< Sig.Object <<< map go <<< L.fromList <<< SM.toList
+  where
+    go (T.Tuple a b) = T.Tuple (string a) b

--- a/src/Data/Json/Extended.purs
+++ b/src/Data/Json/Extended.purs
@@ -1,5 +1,6 @@
 module Data.Json.Extended
-  ( EJsonF(..)
+  ( module Sig
+
   , EJson(..)
   , getEJson
 
@@ -7,164 +8,32 @@ module Data.Json.Extended
   , intoEJson
   , outEJson
 
-  , renderEJsonF
   , renderEJson
 
-  , encodeEJsonF
-  , encodeEJson
-
-  , decodeEJsonF
-  , decodeEJson
-
-  , arbitraryEJsonF
   , arbitraryEJsonOfSize
   ) where
 
 import Prelude
 
-import Control.Alt ((<|>))
-import Control.Bind ((>=>))
-
-import Data.Eq1 (class Eq1)
-import Data.Ord1 (class Ord1)
-
 import Data.Argonaut.Core as JS
-import Data.Argonaut.Encode (class EncodeJson, encodeJson)
-import Data.Argonaut.Decode (class DecodeJson, decodeJson)
-import Data.Argonaut.Combinators ((.?))
+import Data.Argonaut.Encode (class EncodeJson)
+import Data.Argonaut.Decode (class DecodeJson)
 
-import Data.Array as A
 import Data.Either as E
-import Data.Foldable as F
 import Data.Functor.Mu as Mu
-import Data.HugeNum as HN
-import Data.Int as Int
-import Data.List as L
 import Data.Maybe as M
-import Data.StrMap as SM
-import Data.String.Regex as Rx
-import Data.Traversable as TR
-import Data.Tuple as T
 
-import Test.StrongCheck as SC
 import Test.StrongCheck.Gen as Gen
 
--- | The signature of the EJson theory.
-data EJsonF a
-  = Null
-  | String String
-  | Boolean Boolean
-  | Integer Int
-  | Decimal HN.HugeNum
-  | String String
-  | Timestamp String
-  | Date String
-  | Time String
-  | Interval String
-  | ObjectId String
-  | Array (Array a)
-  | OrderedSet (Array a)
-  | Object (Array (T.Tuple a a))
-
-instance functorEJsonF ∷ Functor EJsonF where
-  map f x =
-    case x of
-      Null → Null
-      String str → String str
-      Boolean b → Boolean b
-      Integer i → Integer i
-      Decimal a → Decimal a
-      Timestamp ts → Timestamp ts
-      Date d → Date d
-      Time t → Time t
-      Interval i → Interval i
-      ObjectId oid → ObjectId oid
-      Array xs → Array $ f <$> xs
-      OrderedSet xs → OrderedSet $ f <$> xs
-      Object xs → Object $ bimapTuple f <$> xs
-    where
-      bimapTuple f (T.Tuple a b) =
-        T.Tuple (f a) (f b)
-
-instance eq1EJsonF ∷ Eq1 EJsonF where
-  eq1 Null Null = true
-  eq1 (Boolean b1) (Boolean b2) = b1 == b2
-  eq1 (Integer i) (Integer j) = i == j
-  eq1 (Decimal a) (Decimal b) = a == b
-  eq1 (Integer i) (Decimal b) = HN.fromNumber (Int.toNumber i) == b
-  eq1 (Decimal a) (Integer j) = a == HN.fromNumber (Int.toNumber j)
-  eq1 (String a) (String b) = a == b
-  eq1 (Timestamp a) (Timestamp b) = a == b
-  eq1 (Date a) (Date b) = a == b
-  eq1 (Time a) (Time b) = a == b
-  eq1 (Interval a) (Interval b) = a == b
-  eq1 (ObjectId a) (ObjectId b) = a == b
-  eq1 (OrderedSet xs) (OrderedSet ys) = xs == ys
-  eq1 (Array xs) (Array ys) = xs == ys
-  eq1 (Object xs) (Object ys) = xs == ys
-  eq1 _ _ = false
-
-instance ord1EJsonF ∷ Ord1 EJsonF where
-  compare1 Null Null = EQ
-  compare1 _ Null = GT
-  compare1 Null _ = LT
-
-  compare1 (Boolean b1) (Boolean b2) = compare b1 b2
-  compare1 _ (Boolean _) = GT
-  compare1 (Boolean _) _ = LT
-
-  compare1 (Integer i) (Integer j) = compare i j
-  compare1 (Integer i) (Decimal b) = compare (HN.fromNumber (Int.toNumber i)) b
-  compare1 (Decimal a) (Integer j) = compare a (HN.fromNumber (Int.toNumber j))
-  compare1 _ (Integer _) = GT
-  compare1 (Integer _) _ = LT
-
-  compare1 (Decimal a) (Decimal b) = compare a b
-  compare1 _ (Decimal _) = GT
-  compare1 (Decimal _) _ = LT
-
-  compare1 (String a) (String b) = compare a b
-  compare1 _ (String _) = GT
-  compare1 (String _) _ = LT
-
-  compare1 (Timestamp a) (Timestamp b) = compare a b
-  compare1 _ (Timestamp _) = GT
-  compare1 (Timestamp _) _ = LT
-
-  compare1 (Date a) (Date b) = compare a b
-  compare1 _ (Date _) = GT
-  compare1 (Date _) _ = LT
-
-  compare1 (Time a) (Time b) = compare a b
-  compare1 _ (Time _) = GT
-  compare1 (Time _) _ = LT
-
-  compare1 (Interval a) (Interval b) = compare a b
-  compare1 _ (Interval _) = GT
-  compare1 (Interval _) _ = LT
-
-  compare1 (ObjectId a) (ObjectId b) = compare a b
-  compare1 _ (ObjectId _) = GT
-  compare1 (ObjectId _) _ = LT
-
-  compare1 (OrderedSet a) (OrderedSet b) = compare a b
-  compare1 _ (OrderedSet _) = GT
-  compare1 (OrderedSet _) _ = LT
-
-  compare1 (Array a) (Array b) = compare a b
-  compare1 _ (Array _) = GT
-  compare1 (Array _) _ = LT
-
-  compare1 (Object a) (Object b) = compare a b
-
+import Data.Json.Extended.Signature as Sig
 
 class EJsonView a where
-  intoEJson ∷ EJsonF a → a
-  outEJson ∷ a → E.Either a (EJsonF a)
+  intoEJson ∷ Sig.EJsonF a → a
+  outEJson ∷ a → E.Either a (Sig.EJsonF a)
 
-newtype EJson = EJson (Mu.Mu EJsonF)
+newtype EJson = EJson (Mu.Mu Sig.EJsonF)
 
-getEJson ∷ EJson → Mu.Mu EJsonF
+getEJson ∷ EJson → Mu.Mu Sig.EJsonF
 getEJson (EJson x) = x
 
 instance ejsonViewEJson ∷ EJsonView EJson where
@@ -174,198 +43,43 @@ instance ejsonViewEJson ∷ EJsonView EJson where
 instance showEJson ∷ Show EJson where
   show = renderEJson
 
-instance decodeJsonEJson ∷ DecodeJson EJson where
-  decodeJson = decodeEJson
+instance _decodeJsonEJson ∷ DecodeJson EJson where
+  decodeJson = decodeJsonEJson
 
-instance encodeJsonEJson ∷ EncodeJson EJson where
-  encodeJson = encodeEJson
+instance _encodeJsonEJson ∷ EncodeJson EJson where
+  encodeJson = encodeJsonEJson
 
 -- | This is a _lossy_ encoding of EJSON to JSON; JSON only supports objects with strings
 -- as keys.
-encodeEJson
+encodeJsonEJson
   ∷ EJson
   → JS.Json
-encodeEJson (EJson x) =
-  encodeEJsonF
-    encodeEJson
+encodeJsonEJson (EJson x) =
+  Sig.encodeJsonEJsonF
+    encodeJsonEJson
+    asKey
     (EJson <$> Mu.unroll x)
 
-encodeEJsonF
-  ∷ ∀ a
-  . (EJsonView a)
-  ⇒ (a → JS.Json)
-  → EJsonF a
-  → JS.Json
-encodeEJsonF rec x =
-  case x of
-    Null → JS.jsonNull
-    Boolean b → encodeJson b
-    Integer i → encodeJson i
-    Decimal a → encodeJson $ HN.toNumber a
-    String str → encodeJson str
-    Timestamp str → JS.jsonSingletonObject "$timestamp" $ encodeJson str
-    Time str → JS.jsonSingletonObject "$time" $ encodeJson str
-    Date str → JS.jsonSingletonObject "$date" $ encodeJson str
-    Interval str → JS.jsonSingletonObject "$interval" $ encodeJson str
-    ObjectId str → JS.jsonSingletonObject "$oid" $ encodeJson str
-    OrderedSet xs → JS.jsonSingletonObject "$set" $ encodeJson $ rec <$> xs
-    Array xs → encodeJson $ rec <$> xs
-    Object xs → JS.jsonSingletonObject "$obj" $ encodeJson $ asStrMap xs
-      where
-        tuple
-          ∷ T.Tuple a a
-          → M.Maybe (T.Tuple String JS.Json)
-        tuple (T.Tuple k v) =
-          case outEJson k of
-            E.Right (String str) → pure $ T.Tuple str (rec v)
-            _ → M.Nothing
+  where
+    asKey
+      ∷ EJson
+      → M.Maybe String
+    asKey (EJson x) =
+      case Mu.unroll x of
+        Sig.String k → pure k
+        _ → M.Nothing
 
-        asStrMap
-          ∷ Array (T.Tuple a a)
-          → SM.StrMap JS.Json
-        asStrMap =
-          SM.fromList
-            <<< L.toList
-            <<< A.mapMaybe tuple
-
-decodeEJson
+decodeJsonEJson
   ∷ ∀ a
   . (EJsonView a)
   ⇒ JS.Json
   → E.Either String a
-decodeEJson x =
+decodeJsonEJson x =
   map intoEJson $
-    decodeEJsonF decodeEJson x
-
-decodeEJsonF
-  ∷ ∀ a
-  . (EJsonView a)
-  ⇒ (JS.Json → E.Either String a)
-  → JS.Json
-  → E.Either String (EJsonF a)
-decodeEJsonF rec =
-  JS.foldJson
-    (\_ → pure Null)
-    (pure <<< Boolean)
-    (pure <<< decodeNumber)
-    (pure <<< String)
-    (map Array <<< TR.traverse rec)
-    decodeObject
-
- where
-    decodeNumber
-      ∷ Number
-      → EJsonF a
-    decodeNumber a =
-      case Int.fromNumber a of
-        M.Just i → Integer i
-        M.Nothing → Decimal $ HN.fromNumber a
-
-    getOnlyKey
-      ∷ String
-      → JS.JObject
-      → E.Either String JS.Json
-    getOnlyKey key obj =
-      case SM.keys obj of
-        [_] → obj .? key
-        keys → E.Left $ "Expected '" <> key <> "' to be the only key, but found: " <> show keys
-
-    unwrapLeaf
-      ∷ ∀ b
-      . (DecodeJson b)
-      ⇒ String
-      → (b → EJsonF a)
-      → JS.JObject
-      → E.Either String (EJsonF a)
-    unwrapLeaf key con =
-      getOnlyKey key
-        >=> decodeJson
-        >>> map con
-
-    unwrapBranch
-      ∷ ∀ t
-      . (TR.Traversable t, DecodeJson (t JS.Json))
-      ⇒ String
-      → (t a → EJsonF a)
-      → JS.JObject
-      → E.Either String (EJsonF a)
-    unwrapBranch key con =
-      getOnlyKey key
-        >=> decodeJson
-        >=> TR.traverse rec
-        >>> map con
-
-    unwrapNull
-      ∷ JS.JObject
-      → E.Either String (EJsonF a)
-    unwrapNull =
-      getOnlyKey "$na" >=>
-        JS.foldJsonNull
-          (E.Left "Expected null")
-          (\_ → pure Null)
-
-    decodeObject
-      ∷ JS.JObject
-      → E.Either String (EJsonF a)
-    decodeObject obj =
-      unwrapBranch "$obj" strMapObject obj
-        <|> unwrapBranch "$set" OrderedSet obj
-        <|> unwrapLeaf "$timestamp" Timestamp obj
-        <|> unwrapLeaf "$date" Date obj
-        <|> unwrapLeaf "$time" Time obj
-        <|> unwrapLeaf "$interval" Interval obj
-        <|> unwrapLeaf "$oid" ObjectId obj
-        <|> unwrapNull obj
-        <|> strMapObject <$> TR.traverse rec obj
-
-    strMapObject
-      ∷ SM.StrMap a
-      → EJsonF a
-    strMapObject =
-      Object
-        <<< L.fromList
-        <<< map (\(T.Tuple k v) → T.Tuple (intoEJson $ String k) v)
-        <<< SM.toList
-
-arbitraryDecimal ∷ Gen.Gen HN.HugeNum
-arbitraryDecimal =
-  HN.fromNumber
-    <<< Data.Int.toNumber
-    <$> SC.arbitrary
-
-arbitraryBaseEJsonF ∷ ∀ a. Gen.Gen (EJsonF a)
-arbitraryBaseEJsonF =
-  Gen.oneOf (pure Null)
-    [ Boolean <$> SC.arbitrary
-    , Integer <$> SC.arbitrary
-    , Decimal <$> arbitraryDecimal
-    , String <$> SC.arbitrary
-    , Timestamp <$> SC.arbitrary
-    , Date <$> SC.arbitrary
-    , Time <$> SC.arbitrary
-    , Interval <$> SC.arbitrary
-    , ObjectId <$> SC.arbitrary
-    , pure Null
-    ]
-
-arbitraryEJsonF
-  ∷ ∀ a
-  . Gen.Gen a
-  → Gen.Gen (EJsonF a)
-arbitraryEJsonF rec =
-  Gen.oneOf (pure Null)
-    [ arbitraryBaseEJsonF
-    , OrderedSet <$> Gen.arrayOf rec
-    , Array <$> Gen.arrayOf rec
-    , Object <$> Gen.arrayOf arbitraryTuple
-    ]
-
-  where
-    arbitraryTuple ∷ Gen.Gen (T.Tuple a a)
-    arbitraryTuple =
-      T.Tuple
-        <$> rec
-        <*> rec
+    Sig.decodeJsonEJsonF
+      decodeJsonEJson
+      (Sig.String >>> intoEJson)
+      x
 
 arbitraryEJsonOfSize
   ∷ ∀ a
@@ -375,98 +89,14 @@ arbitraryEJsonOfSize
 arbitraryEJsonOfSize size =
   intoEJson <$>
     case size of
-      0 → arbitraryBaseEJsonF
-      n → arbitraryEJsonF $ arbitraryEJsonOfSize (n - 1)
-
-renderEJsonF
-  ∷ ∀ a
-  . (a → String)
-  → EJsonF a
-  → String
-renderEJsonF rec d =
-  case d of
-    Null → "null"
-    Boolean b → if b then "true" else "false"
-    Integer i → show i
-    Decimal a → HN.toString a
-    String str → stringEJson str
-    Timestamp str → tagged "TIMESTAMP" str
-    Time str → tagged "TIME" str
-    Date str → tagged "DATE" str
-    Interval str → tagged "INTERVAL" str
-    ObjectId str → tagged "OID" str
-    OrderedSet ds → parens $ commaSep ds
-    Array ds → squares $ commaSep ds
-    Object ds → braces $ renderPairs ds
-  where
-    tagged
-      ∷ String
-      → String
-      → String
-    tagged tag str =
-      tag <> parens (stringEJson str)
-
-    replaceAll
-      ∷ String
-      → String
-      → String
-      → String
-    replaceAll i =
-      Rx.replace $
-        Rx.regex i $
-          Rx.noFlags { global = true }
-
-    -- | Surround text in double quotes, escaping internal double quotes.
-    stringEJson
-      ∷ String
-      → String
-    stringEJson str =
-      "\"" <> replaceAll "\"" "\\\"" str <> "\""
-
-    commaSep
-      ∷ ∀ f
-      . (Functor f, F.Foldable f)
-      ⇒ f a
-      → String
-    commaSep =
-      F.intercalate "," <<<
-        map rec
-
-    renderPairs
-      ∷ Array (T.Tuple a a)
-      → String
-    renderPairs =
-      F.intercalate ", " <<<
-        map \(T.Tuple k v) →
-          rec k <> ": " <> rec v
+      0 → Sig.arbitraryBaseEJsonF
+      n → Sig.arbitraryEJsonF $ arbitraryEJsonOfSize (n - 1)
 
 renderEJson
   ∷ EJson
   → String
 renderEJson (EJson x) =
-  renderEJsonF
+  Sig.renderEJsonF
     renderEJson
     (EJson <$> Mu.unroll x)
-
-
-hole ∷ ∀ a. a
-hole = Unsafe.Coerce.unsafeCoerce "a"
-
-parens
-  ∷ String
-  → String
-parens str =
-  "(" <> str <> ")"
-
-squares
-  ∷ String
-  → String
-squares str =
-  "[" <> str <> "]"
-
-braces
-  ∷ String
-  → String
-braces str =
-  "{" <> str <> "}"
 

--- a/src/Data/Json/Extended.purs
+++ b/src/Data/Json/Extended.purs
@@ -1,0 +1,365 @@
+module Data.Json.Extended
+  ( EJsonF(..)
+  , EJson(..)
+  , getEJson
+
+  , class EJsonView
+  , intoEJson
+  , outEJson
+
+  , encodeEJsonF
+
+  , decodeEJsonF
+  , decodeEJson
+
+  , arbitraryEJsonF
+  , arbitraryEJsonOfSize
+  ) where
+
+import Prelude
+
+import Control.Alt ((<|>))
+import Control.Bind ((>=>))
+
+import Data.Eq1 (class Eq1)
+import Data.Ord1 (class Ord1)
+
+import Data.Argonaut.Core as JS
+import Data.Argonaut.Encode (encodeJson)
+import Data.Argonaut.Decode (class DecodeJson, decodeJson)
+import Data.Argonaut.Combinators ((.?))
+
+import Data.Array as A
+import Data.Either as E
+import Data.Functor.Mu as Mu
+import Data.HugeNum as HN
+import Data.Int as Int
+import Data.List as L
+import Data.Maybe as M
+import Data.StrMap as SM
+import Data.Traversable as TR
+import Data.Tuple as T
+
+import Test.StrongCheck as SC
+import Test.StrongCheck.Gen as Gen
+
+-- | The signature of the EJson theory.
+data EJsonF a
+  = Null
+  | String String
+  | Boolean Boolean
+  | Integer Int
+  | Decimal HN.HugeNum
+  | String String
+  | Timestamp String
+  | Date String
+  | Time String
+  | Interval String
+  | ObjectId String
+  | Array (Array a)
+  | OrderedSet (Array a)
+  | Object (Array (T.Tuple a a))
+
+instance functorEJsonF ∷ Functor EJsonF where
+  map f x =
+    case x of
+      Null → Null
+      String str → String str
+      Boolean b → Boolean b
+      Integer i → Integer i
+      Decimal a → Decimal a
+      Timestamp ts → Timestamp ts
+      Date d → Date d
+      Time t → Time t
+      Interval i → Interval i
+      ObjectId oid → ObjectId oid
+      Array xs → Array $ f <$> xs
+      OrderedSet xs → OrderedSet $ f <$> xs
+      Object xs → Object $ bimapTuple f <$> xs
+    where
+      bimapTuple f (T.Tuple a b) =
+        T.Tuple (f a) (f b)
+
+instance eq1EJsonF ∷ Eq1 EJsonF where
+  eq1 Null Null = true
+  eq1 (Boolean b1) (Boolean b2) = b1 == b2
+  eq1 (Integer i) (Integer j) = i == j
+  eq1 (Decimal a) (Decimal b) = a == b
+  eq1 (Integer i) (Decimal b) = HN.fromNumber (Int.toNumber i) == b
+  eq1 (Decimal a) (Integer j) = a == HN.fromNumber (Int.toNumber j)
+  eq1 (String a) (String b) = a == b
+  eq1 (Timestamp a) (Timestamp b) = a == b
+  eq1 (Date a) (Date b) = a == b
+  eq1 (Time a) (Time b) = a == b
+  eq1 (Interval a) (Interval b) = a == b
+  eq1 (ObjectId a) (ObjectId b) = a == b
+  eq1 (OrderedSet xs) (OrderedSet ys) = xs == ys
+  eq1 (Array xs) (Array ys) = xs == ys
+  eq1 (Object xs) (Object ys) = xs == ys
+  eq1 _ _ = false
+
+instance ord1EJsonF ∷ Ord1 EJsonF where
+  compare1 Null Null = EQ
+  compare1 _ Null = GT
+  compare1 Null _ = LT
+
+  compare1 (Boolean b1) (Boolean b2) = compare b1 b2
+  compare1 _ (Boolean _) = GT
+  compare1 (Boolean _) _ = LT
+
+  compare1 (Integer i) (Integer j) = compare i j
+  compare1 (Integer i) (Decimal b) = compare (HN.fromNumber (Int.toNumber i)) b
+  compare1 (Decimal a) (Integer j) = compare a (HN.fromNumber (Int.toNumber j))
+  compare1 _ (Integer _) = GT
+  compare1 (Integer _) _ = LT
+
+  compare1 (Decimal a) (Decimal b) = compare a b
+  compare1 _ (Decimal _) = GT
+  compare1 (Decimal _) _ = LT
+
+  compare1 (String a) (String b) = compare a b
+  compare1 _ (String _) = GT
+  compare1 (String _) _ = LT
+
+  compare1 (Timestamp a) (Timestamp b) = compare a b
+  compare1 _ (Timestamp _) = GT
+  compare1 (Timestamp _) _ = LT
+
+  compare1 (Date a) (Date b) = compare a b
+  compare1 _ (Date _) = GT
+  compare1 (Date _) _ = LT
+
+  compare1 (Time a) (Time b) = compare a b
+  compare1 _ (Time _) = GT
+  compare1 (Time _) _ = LT
+
+  compare1 (Interval a) (Interval b) = compare a b
+  compare1 _ (Interval _) = GT
+  compare1 (Interval _) _ = LT
+
+  compare1 (ObjectId a) (ObjectId b) = compare a b
+  compare1 _ (ObjectId _) = GT
+  compare1 (ObjectId _) _ = LT
+
+  compare1 (OrderedSet a) (OrderedSet b) = compare a b
+  compare1 _ (OrderedSet _) = GT
+  compare1 (OrderedSet _) _ = LT
+
+  compare1 (Array a) (Array b) = compare a b
+  compare1 _ (Array _) = GT
+  compare1 (Array _) _ = LT
+
+  compare1 (Object a) (Object b) = compare a b
+
+
+class EJsonView a where
+  intoEJson ∷ EJsonF a → a
+  outEJson ∷ a → E.Either a (EJsonF a)
+
+newtype EJson = EJson (Mu.Mu EJsonF)
+
+getEJson ∷ EJson → Mu.Mu EJsonF
+getEJson (EJson x) = x
+
+instance ejsonViewEJson ∷ EJsonView EJson where
+  intoEJson = EJson <<< Mu.roll <<< map getEJson
+  outEJson = getEJson >>> Mu.unroll >>> map EJson >>> E.Right
+
+-- | This is a _lossy_ encoding of EJSON to JSON; JSON only supports objects with strings
+-- as keys.
+encodeEJson
+  ∷ EJson
+  → JS.Json
+encodeEJson (EJson x) =
+  encodeEJsonF
+    encodeEJson
+    (EJson <$> Mu.unroll x)
+
+encodeEJsonF
+  ∷ ∀ a
+  . (EJsonView a)
+  ⇒ (a → JS.Json)
+  → EJsonF a
+  → JS.Json
+encodeEJsonF rec x =
+  case x of
+    Null → JS.jsonNull
+    Boolean b → encodeJson b
+    Integer i → encodeJson i
+    Decimal a → encodeJson $ HN.toNumber a
+    String str → encodeJson str
+    Timestamp str → JS.jsonSingletonObject "$timestamp" $ encodeJson str
+    Time str → JS.jsonSingletonObject "$time" $ encodeJson str
+    Date str → JS.jsonSingletonObject "$date" $ encodeJson str
+    Interval str → JS.jsonSingletonObject "$interval" $ encodeJson str
+    ObjectId str → JS.jsonSingletonObject "$oid" $ encodeJson str
+    OrderedSet xs → JS.jsonSingletonObject "$set" $ encodeJson $ rec <$> xs
+    Array xs → encodeJson $ rec <$> xs
+    Object xs → JS.jsonSingletonObject "$obj" $ encodeJson $ asStrMap xs
+      where
+        tuple
+          ∷ T.Tuple a a
+          → M.Maybe (T.Tuple String JS.Json)
+        tuple (T.Tuple k v) =
+          case outEJson k of
+            E.Right (String str) → pure $ T.Tuple str (rec v)
+            _ → M.Nothing
+
+        asStrMap
+          ∷ Array (T.Tuple a a)
+          → SM.StrMap JS.Json
+        asStrMap =
+          SM.fromList
+            <<< L.toList
+            <<< A.mapMaybe tuple
+
+decodeEJson
+  ∷ ∀ a
+  . (EJsonView a)
+  ⇒ JS.Json
+  → E.Either String a
+decodeEJson x =
+  map intoEJson $
+    decodeEJsonF decodeEJson x
+
+decodeEJsonF
+  ∷ ∀ a
+  . (EJsonView a)
+  ⇒ (JS.Json → E.Either String a)
+  → JS.Json
+  → E.Either String (EJsonF a)
+decodeEJsonF rec =
+  JS.foldJson
+    (\_ → pure Null)
+    (pure <<< Boolean)
+    (pure <<< decodeNumber)
+    (pure <<< String)
+    (map Array <<< TR.traverse rec)
+    decodeObject
+
+ where
+    decodeNumber
+      ∷ Number
+      → EJsonF a
+    decodeNumber a =
+      case Int.fromNumber a of
+        M.Just i → Integer i
+        M.Nothing → Decimal $ HN.fromNumber a
+
+    getOnlyKey
+      ∷ String
+      → JS.JObject
+      → E.Either String JS.Json
+    getOnlyKey key obj =
+      case SM.keys obj of
+        [_] → obj .? key
+        keys → E.Left $ "Expected '" <> key <> "' to be the only key, but found: " <> show keys
+
+    unwrapLeaf
+      ∷ ∀ b
+      . (DecodeJson b)
+      ⇒ String
+      → (b → EJsonF a)
+      → JS.JObject
+      → E.Either String (EJsonF a)
+    unwrapLeaf key con =
+      getOnlyKey key
+        >=> decodeJson
+        >>> map con
+
+    unwrapBranch
+      ∷ ∀ t
+      . (TR.Traversable t, DecodeJson (t JS.Json))
+      ⇒ String
+      → (t a → EJsonF a)
+      → JS.JObject
+      → E.Either String (EJsonF a)
+    unwrapBranch key con =
+      getOnlyKey key
+        >=> decodeJson
+        >=> TR.traverse rec
+        >>> map con
+
+    unwrapNull
+      ∷ JS.JObject
+      → E.Either String (EJsonF a)
+    unwrapNull =
+      getOnlyKey "$na" >=>
+        JS.foldJsonNull
+          (E.Left "Expected null")
+          (\_ → pure Null)
+
+    decodeObject
+      ∷ JS.JObject
+      → E.Either String (EJsonF a)
+    decodeObject obj =
+      unwrapBranch "$obj" strMapObject obj
+        <|> unwrapBranch "$set" OrderedSet obj
+        <|> unwrapLeaf "$timestamp" Timestamp obj
+        <|> unwrapLeaf "$date" Date obj
+        <|> unwrapLeaf "$time" Time obj
+        <|> unwrapLeaf "$interval" Interval obj
+        <|> unwrapLeaf "$oid" ObjectId obj
+        <|> unwrapNull obj
+        <|> strMapObject <$> TR.traverse rec obj
+
+    strMapObject
+      ∷ SM.StrMap a
+      → EJsonF a
+    strMapObject =
+      Object
+        <<< L.fromList
+        <<< map (\(T.Tuple k v) → T.Tuple (intoEJson $ String k) v)
+        <<< SM.toList
+
+arbitraryDecimal ∷ Gen.Gen HN.HugeNum
+arbitraryDecimal =
+  HN.fromNumber
+    <<< Data.Int.toNumber
+    <$> SC.arbitrary
+
+arbitraryBaseEJsonF ∷ ∀ a. Gen.Gen (EJsonF a)
+arbitraryBaseEJsonF =
+  Gen.oneOf (pure Null)
+    [ Boolean <$> SC.arbitrary
+    , Integer <$> SC.arbitrary
+    , Decimal <$> arbitraryDecimal
+    , String <$> SC.arbitrary
+    , Timestamp <$> SC.arbitrary
+    , Date <$> SC.arbitrary
+    , Time <$> SC.arbitrary
+    , Interval <$> SC.arbitrary
+    , ObjectId <$> SC.arbitrary
+    , pure Null
+    ]
+
+arbitraryEJsonF
+  ∷ ∀ a
+  . Gen.Gen a
+  → Gen.Gen (EJsonF a)
+arbitraryEJsonF rec =
+  Gen.oneOf (pure Null)
+    [ arbitraryBaseEJsonF
+    , OrderedSet <$> Gen.arrayOf rec
+    , Array <$> Gen.arrayOf rec
+    , Object <$> Gen.arrayOf arbitraryTuple
+    ]
+
+  where
+    arbitraryTuple ∷ Gen.Gen (T.Tuple a a)
+    arbitraryTuple =
+      T.Tuple
+        <$> rec
+        <*> rec
+
+arbitraryEJsonOfSize
+  ∷ ∀ a
+  . (EJsonView a)
+  ⇒ Gen.Size
+  → Gen.Gen a
+arbitraryEJsonOfSize size =
+  intoEJson <$>
+    case size of
+      0 → arbitraryBaseEJsonF
+      n → arbitraryEJsonF $ arbitraryEJsonOfSize (n - 1)
+

--- a/src/Data/Json/Extended.purs
+++ b/src/Data/Json/Extended.purs
@@ -29,7 +29,7 @@ import Data.Eq1 (class Eq1)
 import Data.Ord1 (class Ord1)
 
 import Data.Argonaut.Core as JS
-import Data.Argonaut.Encode (encodeJson)
+import Data.Argonaut.Encode (class EncodeJson, encodeJson)
 import Data.Argonaut.Decode (class DecodeJson, decodeJson)
 import Data.Argonaut.Combinators ((.?))
 
@@ -170,6 +170,15 @@ getEJson (EJson x) = x
 instance ejsonViewEJson ∷ EJsonView EJson where
   intoEJson = EJson <<< Mu.roll <<< map getEJson
   outEJson = getEJson >>> Mu.unroll >>> map EJson >>> E.Right
+
+instance showEJson ∷ Show EJson where
+  show = renderEJson
+
+instance decodeJsonEJson ∷ DecodeJson EJson where
+  decodeJson = decodeEJson
+
+instance encodeJsonEJson ∷ EncodeJson EJson where
+  encodeJson = encodeEJson
 
 -- | This is a _lossy_ encoding of EJSON to JSON; JSON only supports objects with strings
 -- as keys.

--- a/src/Data/Json/Extended/Signature.purs
+++ b/src/Data/Json/Extended/Signature.purs
@@ -1,0 +1,12 @@
+module Data.Json.Extended.Signature
+  ( module Core
+  , module Render
+  , module Gen
+  , module Json
+  ) where
+
+import Data.Json.Extended.Signature.Core as Core
+import Data.Json.Extended.Signature.Render as Render
+import Data.Json.Extended.Signature.Gen as Gen
+import Data.Json.Extended.Signature.Json as Json
+

--- a/src/Data/Json/Extended/Signature/Core.purs
+++ b/src/Data/Json/Extended/Signature/Core.purs
@@ -1,0 +1,120 @@
+module Data.Json.Extended.Signature.Core
+  ( EJsonF(..)
+  ) where
+
+import Prelude
+
+import Data.Eq1 (class Eq1)
+import Data.Ord1 (class Ord1)
+
+import Data.HugeNum as HN
+import Data.Int as Int
+import Data.Tuple as T
+
+-- | The signature endofunctor for the EJson theory.
+data EJsonF a
+  = Null
+  | String String
+  | Boolean Boolean
+  | Integer Int
+  | Decimal HN.HugeNum
+  | String String
+  | Timestamp String
+  | Date String
+  | Time String
+  | Interval String
+  | ObjectId String
+  | Array (Array a)
+  | OrderedSet (Array a)
+  | Object (Array (T.Tuple a a))
+
+instance functorEJsonF ∷ Functor EJsonF where
+  map f x =
+    case x of
+      Null → Null
+      String str → String str
+      Boolean b → Boolean b
+      Integer i → Integer i
+      Decimal a → Decimal a
+      Timestamp ts → Timestamp ts
+      Date d → Date d
+      Time t → Time t
+      Interval i → Interval i
+      ObjectId oid → ObjectId oid
+      Array xs → Array $ f <$> xs
+      OrderedSet xs → OrderedSet $ f <$> xs
+      Object xs → Object $ bimapTuple f <$> xs
+    where
+      bimapTuple f (T.Tuple a b) =
+        T.Tuple (f a) (f b)
+
+instance eq1EJsonF ∷ Eq1 EJsonF where
+  eq1 Null Null = true
+  eq1 (Boolean b1) (Boolean b2) = b1 == b2
+  eq1 (Integer i) (Integer j) = i == j
+  eq1 (Decimal a) (Decimal b) = a == b
+  eq1 (Integer i) (Decimal b) = HN.fromNumber (Int.toNumber i) == b
+  eq1 (Decimal a) (Integer j) = a == HN.fromNumber (Int.toNumber j)
+  eq1 (String a) (String b) = a == b
+  eq1 (Timestamp a) (Timestamp b) = a == b
+  eq1 (Date a) (Date b) = a == b
+  eq1 (Time a) (Time b) = a == b
+  eq1 (Interval a) (Interval b) = a == b
+  eq1 (ObjectId a) (ObjectId b) = a == b
+  eq1 (OrderedSet xs) (OrderedSet ys) = xs == ys
+  eq1 (Array xs) (Array ys) = xs == ys
+  eq1 (Object xs) (Object ys) = xs == ys
+  eq1 _ _ = false
+
+instance ord1EJsonF ∷ Ord1 EJsonF where
+  compare1 Null Null = EQ
+  compare1 _ Null = GT
+  compare1 Null _ = LT
+
+  compare1 (Boolean b1) (Boolean b2) = compare b1 b2
+  compare1 _ (Boolean _) = GT
+  compare1 (Boolean _) _ = LT
+
+  compare1 (Integer i) (Integer j) = compare i j
+  compare1 (Integer i) (Decimal b) = compare (HN.fromNumber (Int.toNumber i)) b
+  compare1 (Decimal a) (Integer j) = compare a (HN.fromNumber (Int.toNumber j))
+  compare1 _ (Integer _) = GT
+  compare1 (Integer _) _ = LT
+
+  compare1 (Decimal a) (Decimal b) = compare a b
+  compare1 _ (Decimal _) = GT
+  compare1 (Decimal _) _ = LT
+
+  compare1 (String a) (String b) = compare a b
+  compare1 _ (String _) = GT
+  compare1 (String _) _ = LT
+
+  compare1 (Timestamp a) (Timestamp b) = compare a b
+  compare1 _ (Timestamp _) = GT
+  compare1 (Timestamp _) _ = LT
+
+  compare1 (Date a) (Date b) = compare a b
+  compare1 _ (Date _) = GT
+  compare1 (Date _) _ = LT
+
+  compare1 (Time a) (Time b) = compare a b
+  compare1 _ (Time _) = GT
+  compare1 (Time _) _ = LT
+
+  compare1 (Interval a) (Interval b) = compare a b
+  compare1 _ (Interval _) = GT
+  compare1 (Interval _) _ = LT
+
+  compare1 (ObjectId a) (ObjectId b) = compare a b
+  compare1 _ (ObjectId _) = GT
+  compare1 (ObjectId _) _ = LT
+
+  compare1 (OrderedSet a) (OrderedSet b) = compare a b
+  compare1 _ (OrderedSet _) = GT
+  compare1 (OrderedSet _) _ = LT
+
+  compare1 (Array a) (Array b) = compare a b
+  compare1 _ (Array _) = GT
+  compare1 (Array _) _ = LT
+
+  compare1 (Object a) (Object b) = compare a b

--- a/src/Data/Json/Extended/Signature/Core.purs
+++ b/src/Data/Json/Extended/Signature/Core.purs
@@ -54,8 +54,8 @@ instance eq1EJsonF ∷ Eq1 EJsonF where
   eq1 (Boolean b1) (Boolean b2) = b1 == b2
   eq1 (Integer i) (Integer j) = i == j
   eq1 (Decimal a) (Decimal b) = a == b
-  eq1 (Integer i) (Decimal b) = HN.fromNumber (Int.toNumber i) == b
-  eq1 (Decimal a) (Integer j) = a == HN.fromNumber (Int.toNumber j)
+  eq1 (Integer i) (Decimal b) = intToHugeNum i == b
+  eq1 (Decimal a) (Integer j) = a == intToHugeNum j
   eq1 (String a) (String b) = a == b
   eq1 (Timestamp a) (Timestamp b) = a == b
   eq1 (Date a) (Date b) = a == b
@@ -87,6 +87,13 @@ isSubobject xs ys =
     true
     xs
 
+intToHugeNum
+  ∷ Int
+  → HN.HugeNum
+intToHugeNum =
+  HN.fromNumber
+    <<< Int.toNumber
+
 instance ord1EJsonF ∷ Ord1 EJsonF where
   compare1 Null Null = EQ
   compare1 _ Null = GT
@@ -97,8 +104,8 @@ instance ord1EJsonF ∷ Ord1 EJsonF where
   compare1 (Boolean _) _ = LT
 
   compare1 (Integer i) (Integer j) = compare i j
-  compare1 (Integer i) (Decimal b) = compare (HN.fromNumber (Int.toNumber i)) b
-  compare1 (Decimal a) (Integer j) = compare a (HN.fromNumber (Int.toNumber j))
+  compare1 (Integer i) (Decimal b) = compare (intToHugeNum i) b
+  compare1 (Decimal a) (Integer j) = compare a (intToHugeNum j)
   compare1 _ (Integer _) = GT
   compare1 (Integer _) _ = LT
 

--- a/src/Data/Json/Extended/Signature/Core.purs
+++ b/src/Data/Json/Extended/Signature/Core.purs
@@ -13,6 +13,7 @@ import Data.Int as Int
 import Data.List as L
 import Data.Map as Map
 import Data.Tuple as T
+import Data.Bifunctor as BF
 
 -- | The signature endofunctor for the EJson theory.
 data EJsonF a
@@ -46,10 +47,7 @@ instance functorEJsonF ∷ Functor EJsonF where
       ObjectId oid → ObjectId oid
       Array xs → Array $ f <$> xs
       OrderedSet xs → OrderedSet $ f <$> xs
-      Object xs → Object $ bimapTuple f <$> xs
-    where
-      bimapTuple f (T.Tuple a b) =
-        T.Tuple (f a) (f b)
+      Object xs → Object $ BF.bimap f f <$> xs
 
 instance eq1EJsonF ∷ Eq1 EJsonF where
   eq1 Null Null = true

--- a/src/Data/Json/Extended/Signature/Gen.purs
+++ b/src/Data/Json/Extended/Signature/Gen.purs
@@ -73,5 +73,4 @@ distinctArrayOf =
 arbitraryDecimal ∷ Gen.Gen HN.HugeNum
 arbitraryDecimal =
   HN.fromNumber
-    <<< Data.Int.toNumber
     <$> SC.arbitrary

--- a/src/Data/Json/Extended/Signature/Gen.purs
+++ b/src/Data/Json/Extended/Signature/Gen.purs
@@ -1,0 +1,53 @@
+module Data.Json.Extended.Signature.Gen
+  ( arbitraryBaseEJsonF
+  , arbitraryEJsonF
+  ) where
+
+import Prelude
+
+import Data.Json.Extended.Signature.Core (EJsonF(..))
+import Data.Tuple as T
+import Data.HugeNum as HN
+
+import Test.StrongCheck as SC
+import Test.StrongCheck.Gen as Gen
+
+arbitraryBaseEJsonF ∷ ∀ a. Gen.Gen (EJsonF a)
+arbitraryBaseEJsonF =
+  Gen.oneOf (pure Null)
+    [ Boolean <$> SC.arbitrary
+    , Integer <$> SC.arbitrary
+    , Decimal <$> arbitraryDecimal
+    , String <$> SC.arbitrary
+    , Timestamp <$> SC.arbitrary
+    , Date <$> SC.arbitrary
+    , Time <$> SC.arbitrary
+    , Interval <$> SC.arbitrary
+    , ObjectId <$> SC.arbitrary
+    , pure Null
+    ]
+
+arbitraryEJsonF
+  ∷ ∀ a
+  . Gen.Gen a
+  → Gen.Gen (EJsonF a)
+arbitraryEJsonF rec =
+  Gen.oneOf (pure Null)
+    [ arbitraryBaseEJsonF
+    , OrderedSet <$> Gen.arrayOf rec
+    , Array <$> Gen.arrayOf rec
+    , Object <$> Gen.arrayOf arbitraryTuple
+    ]
+
+  where
+    arbitraryTuple ∷ Gen.Gen (T.Tuple a a)
+    arbitraryTuple =
+      T.Tuple
+        <$> rec
+        <*> rec
+
+arbitraryDecimal ∷ Gen.Gen HN.HugeNum
+arbitraryDecimal =
+  HN.fromNumber
+    <<< Data.Int.toNumber
+    <$> SC.arbitrary

--- a/src/Data/Json/Extended/Signature/Json.purs
+++ b/src/Data/Json/Extended/Signature/Json.purs
@@ -1,0 +1,153 @@
+module Data.Json.Extended.Signature.Json where
+
+import Prelude
+
+import Control.Alt ((<|>))
+import Control.Bind ((>=>))
+
+import Data.Argonaut.Core as JS
+import Data.Argonaut.Encode (encodeJson)
+import Data.Argonaut.Decode (class DecodeJson, decodeJson)
+import Data.Argonaut.Combinators ((.?))
+
+import Data.Array as A
+import Data.Either as E
+import Data.HugeNum as HN
+import Data.Int as Int
+import Data.List as L
+import Data.Maybe as M
+import Data.StrMap as SM
+import Data.Traversable as TR
+import Data.Tuple as T
+
+import Data.Json.Extended.Signature.Core (EJsonF(..))
+
+
+encodeJsonEJsonF
+  ∷ ∀ a
+  . (a → JS.Json)
+  → (a → M.Maybe String)
+  → EJsonF a
+  → JS.Json
+encodeJsonEJsonF rec asKey x =
+  case x of
+    Null → JS.jsonNull
+    Boolean b → encodeJson b
+    Integer i → encodeJson i
+    Decimal a → encodeJson $ HN.toNumber a
+    String str → encodeJson str
+    Timestamp str → JS.jsonSingletonObject "$timestamp" $ encodeJson str
+    Time str → JS.jsonSingletonObject "$time" $ encodeJson str
+    Date str → JS.jsonSingletonObject "$date" $ encodeJson str
+    Interval str → JS.jsonSingletonObject "$interval" $ encodeJson str
+    ObjectId str → JS.jsonSingletonObject "$oid" $ encodeJson str
+    OrderedSet xs → JS.jsonSingletonObject "$set" $ encodeJson $ rec <$> xs
+    Array xs → encodeJson $ rec <$> xs
+    Object xs → JS.jsonSingletonObject "$obj" $ encodeJson $ asStrMap xs
+      where
+        tuple
+          ∷ T.Tuple a a
+          → M.Maybe (T.Tuple String JS.Json)
+        tuple (T.Tuple k v) =
+          T.Tuple
+            <$> asKey k
+            <*> pure (rec v)
+
+        asStrMap
+          ∷ Array (T.Tuple a a)
+          → SM.StrMap JS.Json
+        asStrMap =
+          SM.fromList
+            <<< L.toList
+            <<< A.mapMaybe tuple
+
+decodeJsonEJsonF
+  ∷ ∀ a
+  . (JS.Json → E.Either String a)
+  → (String → a)
+  → JS.Json
+  → E.Either String (EJsonF a)
+decodeJsonEJsonF rec makeKey =
+  JS.foldJson
+    (\_ → pure Null)
+    (pure <<< Boolean)
+    (pure <<< decodeNumber)
+    (pure <<< String)
+    (map Array <<< TR.traverse rec)
+    decodeObject
+
+ where
+    decodeNumber
+      ∷ Number
+      → EJsonF a
+    decodeNumber a =
+      case Int.fromNumber a of
+        M.Just i → Integer i
+        M.Nothing → Decimal $ HN.fromNumber a
+
+    getOnlyKey
+      ∷ String
+      → JS.JObject
+      → E.Either String JS.Json
+    getOnlyKey key obj =
+      case SM.keys obj of
+        [_] → obj .? key
+        keys → E.Left $ "Expected '" <> key <> "' to be the only key, but found: " <> show keys
+
+    unwrapLeaf
+      ∷ ∀ b
+      . (DecodeJson b)
+      ⇒ String
+      → (b → EJsonF a)
+      → JS.JObject
+      → E.Either String (EJsonF a)
+    unwrapLeaf key con =
+      getOnlyKey key
+        >=> decodeJson
+        >>> map con
+
+    unwrapBranch
+      ∷ ∀ t
+      . (TR.Traversable t, DecodeJson (t JS.Json))
+      ⇒ String
+      → (t a → EJsonF a)
+      → JS.JObject
+      → E.Either String (EJsonF a)
+    unwrapBranch key con =
+      getOnlyKey key
+        >=> decodeJson
+        >=> TR.traverse rec
+        >>> map con
+
+    unwrapNull
+      ∷ JS.JObject
+      → E.Either String (EJsonF a)
+    unwrapNull =
+      getOnlyKey "$na" >=>
+        JS.foldJsonNull
+          (E.Left "Expected null")
+          (\_ → pure Null)
+
+    decodeObject
+      ∷ JS.JObject
+      → E.Either String (EJsonF a)
+    decodeObject obj =
+      unwrapBranch "$obj" strMapObject obj
+        <|> unwrapBranch "$set" OrderedSet obj
+        <|> unwrapLeaf "$timestamp" Timestamp obj
+        <|> unwrapLeaf "$date" Date obj
+        <|> unwrapLeaf "$time" Time obj
+        <|> unwrapLeaf "$interval" Interval obj
+        <|> unwrapLeaf "$oid" ObjectId obj
+        <|> unwrapNull obj
+        <|> strMapObject <$> TR.traverse rec obj
+
+    strMapObject
+      ∷ SM.StrMap a
+      → EJsonF a
+    strMapObject =
+      Object
+        <<< L.fromList
+        <<< map (\(T.Tuple k v) → T.Tuple (makeKey k) v)
+        <<< SM.toList
+

--- a/src/Data/Json/Extended/Signature/Render.purs
+++ b/src/Data/Json/Extended/Signature/Render.purs
@@ -1,0 +1,93 @@
+module Data.Json.Extended.Signature.Render
+  ( renderEJsonF
+  ) where
+
+import Prelude
+
+import Data.Foldable as F
+import Data.HugeNum as HN
+import Data.String.Regex as Rx
+import Data.Tuple as T
+
+import Data.Json.Extended.Signature.Core (EJsonF(..))
+
+renderEJsonF
+  ∷ ∀ a
+  . (a → String)
+  → EJsonF a
+  → String
+renderEJsonF rec d =
+  case d of
+    Null → "null"
+    Boolean b → if b then "true" else "false"
+    Integer i → show i
+    Decimal a → HN.toString a
+    String str → stringEJson str
+    Timestamp str → tagged "TIMESTAMP" str
+    Time str → tagged "TIME" str
+    Date str → tagged "DATE" str
+    Interval str → tagged "INTERVAL" str
+    ObjectId str → tagged "OID" str
+    OrderedSet ds → parens $ commaSep ds
+    Array ds → squares $ commaSep ds
+    Object ds → braces $ renderPairs ds
+  where
+    tagged
+      ∷ String
+      → String
+      → String
+    tagged tag str =
+      tag <> parens (stringEJson str)
+
+    replaceAll
+      ∷ String
+      → String
+      → String
+      → String
+    replaceAll i =
+      Rx.replace $
+        Rx.regex i $
+          Rx.noFlags { global = true }
+
+    -- | Surround text in double quotes, escaping internal double quotes.
+    stringEJson
+      ∷ String
+      → String
+    stringEJson str =
+      "\"" <> replaceAll "\"" "\\\"" str <> "\""
+
+    commaSep
+      ∷ ∀ f
+      . (Functor f, F.Foldable f)
+      ⇒ f a
+      → String
+    commaSep =
+      F.intercalate "," <<<
+        map rec
+
+    renderPairs
+      ∷ Array (T.Tuple a a)
+      → String
+    renderPairs =
+      F.intercalate ", " <<<
+        map \(T.Tuple k v) →
+          rec k <> ": " <> rec v
+
+parens
+  ∷ String
+  → String
+parens str =
+  "(" <> str <> ")"
+
+squares
+  ∷ String
+  → String
+squares str =
+  "[" <> str <> "]"
+
+braces
+  ∷ String
+  → String
+braces str =
+  "{" <> str <> "}"
+

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -30,6 +30,3 @@ main = do
     case decodeJson (encodeJson x) of
       E.Right y → x == y SC.<?> "Mismatch:\n" <> show x <> "\n" <> show y
       E.Left err → SC.Failed $ "Parse error: " <> err
-
-hole ∷ ∀ a. a
-hole = Unsafe.Coerce.unsafeCoerce "a"

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -1,0 +1,35 @@
+module Test.Main where
+
+import Prelude
+import Control.Monad.Eff (Eff)
+import Control.Monad.Eff.Exception (EXCEPTION)
+import Control.Monad.Eff.Random (RANDOM)
+import Control.Monad.Eff.Console (CONSOLE)
+
+import Data.Argonaut.Decode (decodeJson)
+import Data.Argonaut.Encode (encodeJson)
+import Data.Either as E
+import Data.Json.Extended (EJson, arbitraryJsonEncodableEJsonOfSize)
+
+import Test.StrongCheck as SC
+
+type TestEffects =
+  ( err ∷ EXCEPTION
+  , random ∷ RANDOM
+  , console ∷ CONSOLE
+  )
+
+newtype ArbEJson = ArbEJson EJson
+
+instance arbitraryArbEJson ∷ SC.Arbitrary ArbEJson where
+  arbitrary = ArbEJson <$> arbitraryJsonEncodableEJsonOfSize 2
+
+main :: Eff TestEffects Unit
+main = do
+  SC.quickCheck \(ArbEJson x) →
+    case decodeJson (encodeJson x) of
+      E.Right y → x == y SC.<?> "Mismatch:\n" <> show x <> "\n" <> show y
+      E.Left err → SC.Failed $ "Parse error: " <> err
+
+hole ∷ ∀ a. a
+hole = Unsafe.Coerce.unsafeCoerce "a"


### PR DESCRIPTION
What we've been calling "SQL^2 Literals" in SlamData is really just the EJSON ("Extended JSON") language.
- [x] EJson theory signature (`EJsonF`)
- [x] `EJson` as least fixed point of signature endofunctor
- [x] Standard type classes (`Eq1, Ord1, Functor`)
- [x] Lossy JSON (de)serialization
- [x] StrongCheck generators
- [x] faithful EJson renderer
- [x] Property tests

(Related discussion: https://github.com/quasar-analytics/sql2-spec/issues/1)
