### PR TITLE
SD-1575: add parser

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,6 +17,7 @@
     "purescript-fixed-points": "^0.1.0",
     "purescript-hugenums": "^1.3.1",
     "purescript-maps": "^0.5.7",
+    "purescript-parsing": "^0.8.0",
     "purescript-strongcheck": "^0.14.7"
   }
 }

--- a/src/Data/Json/Extended.purs
+++ b/src/Data/Json/Extended.purs
@@ -22,12 +22,15 @@ module Data.Json.Extended
   , array
 
   , renderEJson
+  , parseEJson
 
   , arbitraryEJsonOfSize
   , arbitraryJsonEncodableEJsonOfSize
   ) where
 
 import Prelude
+
+import Control.Lazy as Lazy
 
 import Data.Eq1 (eq1)
 import Data.Ord1 (compare1)
@@ -44,6 +47,8 @@ import Data.Tuple as T
 
 import Test.StrongCheck as SC
 import Test.StrongCheck.Gen as Gen
+
+import Text.Parsing.Parser as P
 
 import Data.Json.Extended.Signature as Sig
 
@@ -139,6 +144,17 @@ renderEJson (EJson x) =
   Sig.renderEJsonF
     renderEJson
     (EJson <$> Mu.unroll x)
+
+-- | A closed parser of SQL^2 constant expressions
+parseEJson
+  ∷ forall m
+  . (Monad m)
+  ⇒ P.ParserT String m EJson
+parseEJson =
+  Lazy.fix \f →
+    roll <$>
+      Sig.parseEJsonF f
+
 
 null ∷ EJson
 null = roll Sig.Null

--- a/src/Data/Json/Extended/Signature.purs
+++ b/src/Data/Json/Extended/Signature.purs
@@ -1,12 +1,14 @@
 module Data.Json.Extended.Signature
   ( module Core
   , module Render
+  , module Parse
   , module Gen
   , module Json
   ) where
 
 import Data.Json.Extended.Signature.Core as Core
 import Data.Json.Extended.Signature.Render as Render
+import Data.Json.Extended.Signature.Parse as Parse
 import Data.Json.Extended.Signature.Gen as Gen
 import Data.Json.Extended.Signature.Json as Json
 

--- a/src/Data/Json/Extended/Signature/Parse.purs
+++ b/src/Data/Json/Extended/Signature/Parse.purs
@@ -1,0 +1,257 @@
+module Data.Json.Extended.Signature.Parse
+  ( parseEJsonF
+  ) where
+
+import Prelude
+
+import Control.Alt ((<|>))
+import Control.Apply ((*>), (<*))
+import Data.Functor ((<$), ($>))
+
+import Data.Array as A
+import Data.Foldable as F
+import Data.HugeNum as HN
+import Data.Int as Int
+import Data.List as L
+import Data.String as S
+import Data.Tuple as T
+
+import Data.Json.Extended.Signature.Core (EJsonF(..))
+
+import Text.Parsing.Parser as P
+import Text.Parsing.Parser.Combinators as PC
+import Text.Parsing.Parser.String as PS
+
+parens
+  ∷ ∀ m a
+  . (Monad m)
+  ⇒ P.ParserT String m a
+  → P.ParserT String m a
+parens =
+  PC.between
+    (PS.string "(")
+    (PS.string ")")
+
+squares
+  ∷ ∀ m a
+  . (Monad m)
+  ⇒ P.ParserT String m a
+  → P.ParserT String m a
+squares =
+  PC.between
+    (PS.string "[")
+    (PS.string "]")
+
+braces
+  ∷ ∀ m a
+  . (Monad m)
+  ⇒ P.ParserT String m a
+  → P.ParserT String m a
+braces =
+  PC.between
+    (PS.string "{")
+    (PS.string "}")
+
+commaSep
+  ∷ ∀ m a
+  . (Monad m)
+  ⇒ P.ParserT String m a
+  → P.ParserT String m (L.List a)
+commaSep =
+  flip PC.sepBy $
+    PS.skipSpaces
+      *> PS.string ","
+      <* PS.skipSpaces
+
+stringLiteral
+  ∷ ∀ m
+  . (Monad m)
+  ⇒ P.ParserT String m String
+stringLiteral =
+  PC.between quote quote (A.many stringChar)
+    <#> S.fromCharArray
+
+  where
+    quote = PS.string "\""
+
+    stringChar =
+      PC.try stringEscape
+        <|> stringLetter
+
+    stringLetter =
+      PS.satisfy \c →
+        c /= '"'
+
+    stringEscape =
+      PS.string "\\\"" $> '"'
+
+taggedLiteral
+  ∷ ∀ m
+  . (Monad m)
+  ⇒ String
+  → P.ParserT String m String
+taggedLiteral tag =
+  PC.try $
+    PS.string tag
+      *> parens stringLiteral
+
+anyString
+  ∷ ∀ m
+  . (Monad m)
+  ⇒ P.ParserT String m String
+anyString =
+  A.many PS.anyChar
+    <#> S.fromCharArray
+
+parseBoolean
+  ∷ ∀ m
+  . (Monad m)
+  ⇒ P.ParserT String m Boolean
+parseBoolean =
+  PC.choice
+    [ true <$ PS.string "true"
+    , false <$ PS.string "false"
+    ]
+
+parseDigit
+  ∷ ∀ m
+   . (Monad m)
+  ⇒ P.ParserT String m Int
+parseDigit =
+  PC.choice
+    [ 0 <$ PS.string "0"
+    , 1 <$ PS.string "1"
+    , 2 <$ PS.string "2"
+    , 3 <$ PS.string "3"
+    , 4 <$ PS.string "4"
+    , 5 <$ PS.string "5"
+    , 6 <$ PS.string "6"
+    , 7 <$ PS.string "7"
+    , 8 <$ PS.string "8"
+    , 9 <$ PS.string "9"
+    ]
+
+many1
+  ∷ ∀ m s a
+  . (Monad m)
+  ⇒ P.ParserT s m a
+  → P.ParserT s m (L.List a)
+many1 p =
+  L.Cons
+    <$> p
+    <*> L.many p
+
+parseNat
+  ∷ ∀ m
+  . (Monad m)
+  ⇒ P.ParserT String m Int
+parseNat =
+  many1 parseDigit
+    <#> F.foldl (\a i → a * 10 + i) 0
+
+parseNegative
+  ∷ ∀ m a
+  . (Monad m, Ring a)
+  ⇒ P.ParserT String m a
+  → P.ParserT String m a
+parseNegative p =
+  PS.string "-"
+    *> PS.skipSpaces
+    *> p
+    <#> negate
+
+parsePositive
+  ∷ ∀ m a
+  . (Monad m, Ring a)
+  ⇒ P.ParserT String m a
+  → P.ParserT String m a
+parsePositive p =
+  PC.optional (PS.string "+" *> PS.skipSpaces)
+    *> p
+
+parseSigned
+  ∷ ∀ m a
+  . (Monad m, Ring a)
+  ⇒ P.ParserT String m a
+  → P.ParserT String m a
+parseSigned p =
+  parseNegative p
+    <|> parsePositive p
+
+parseInt
+  ∷ ∀ m
+  . (Monad m)
+  ⇒ P.ParserT String m Int
+parseInt =
+  parseSigned parseNat
+
+parseExponent
+  ∷ ∀ m
+  . (Monad m)
+  ⇒ P.ParserT String m Int
+parseExponent =
+  (PS.string "e" <|> PS.string "E")
+    *> parseInt
+
+parsePositiveDecimal
+  ∷ ∀ m
+  . (Monad m)
+  ⇒ P.ParserT String m HN.HugeNum
+parsePositiveDecimal = do
+  let ten = HN.fromNumber 10.0
+  lhs ← PC.try $ fromInt <$> parseNat <* PS.string "."
+  rhs ← A.many parseDigit <#> F.foldr (\d f → divNum (f + fromInt d) ten) zero
+  exp ← PC.option 0 parseExponent
+  pure $ (lhs + rhs) * HN.pow ten exp
+
+  where
+    fromInt = HN.fromNumber <<< Int.toNumber
+
+    -- TODO: remove when HugeNum adds division
+    divNum a b =
+      HN.fromNumber $
+        HN.toNumber a / HN.toNumber b
+
+parseDecimal
+  ∷ ∀ m
+  . (Monad m)
+  ⇒ P.ParserT String m HN.HugeNum
+parseDecimal =
+  parseSigned parsePositiveDecimal
+
+-- | Parse one layer of structure.
+parseEJsonF
+  ∷ ∀ m a
+  . (Monad m)
+  ⇒ P.ParserT String m a
+  → P.ParserT String m (EJsonF a)
+parseEJsonF rec =
+  PC.choice $
+    [ Null <$ PS.string "null"
+    , Boolean <$> parseBoolean
+    , Integer <$> parseInt
+    , Decimal <$> parseDecimal
+    , String <$> stringLiteral
+    , Timestamp <$> taggedLiteral "TIMESTAMP"
+    , Time <$> taggedLiteral "TIME"
+    , Date <$> taggedLiteral "DATE"
+    , Interval <$> taggedLiteral "INTERVAL"
+    , ObjectId <$> taggedLiteral "OID"
+    , OrderedSet <<< L.fromList <$> parens (commaSep rec)
+    , Array <<< L.fromList <$> squares (commaSep rec)
+    , Object <<< L.fromList <$> braces (commaSep parseAssignment)
+    ]
+
+  where
+    parseColon ∷ P.ParserT String m String
+    parseColon =
+      PS.skipSpaces
+        *> PS.string ":"
+        <* PS.skipSpaces
+
+    parseAssignment ∷ P.ParserT String m (T.Tuple a a)
+    parseAssignment =
+      T.Tuple
+        <$> rec <* parseColon
+        <*> rec
+

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -9,7 +9,9 @@ import Control.Monad.Eff.Console (CONSOLE)
 import Data.Argonaut.Decode (decodeJson)
 import Data.Argonaut.Encode (encodeJson)
 import Data.Either as E
-import Data.Json.Extended (EJson, arbitraryJsonEncodableEJsonOfSize)
+import Data.Json.Extended (EJson, arbitraryJsonEncodableEJsonOfSize, arbitraryEJsonOfSize, renderEJson, parseEJson)
+
+import Text.Parsing.Parser as P
 
 import Test.StrongCheck as SC
 
@@ -19,14 +21,30 @@ type TestEffects =
   , console ∷ CONSOLE
   )
 
+newtype ArbJsonEncodableEJson = ArbJsonEncodableEJson EJson
 newtype ArbEJson = ArbEJson EJson
 
-instance arbitraryArbEJson ∷ SC.Arbitrary ArbEJson where
-  arbitrary = ArbEJson <$> arbitraryJsonEncodableEJsonOfSize 2
+instance arbitraryArbJsonEncodableEJson ∷ SC.Arbitrary ArbJsonEncodableEJson where
+  arbitrary = ArbJsonEncodableEJson <$> arbitraryJsonEncodableEJsonOfSize 2
 
-main :: Eff TestEffects Unit
-main = do
-  SC.quickCheck \(ArbEJson x) →
+instance arbitraryArbEJson ∷ SC.Arbitrary ArbEJson where
+  arbitrary = ArbEJson <$> arbitraryEJsonOfSize 2
+
+testJsonSerialization ∷ Eff TestEffects Unit
+testJsonSerialization =
+  SC.quickCheck \(ArbJsonEncodableEJson x) →
     case decodeJson (encodeJson x) of
       E.Right y → x == y SC.<?> "Mismatch:\n" <> show x <> "\n" <> show y
       E.Left err → SC.Failed $ "Parse error: " <> err
+
+testRenderParse ∷ Eff TestEffects Unit
+testRenderParse =
+  SC.quickCheck \(ArbEJson x) →
+    case P.runParser (renderEJson x) parseEJson of
+      E.Right y → x == y SC.<?> "Mismatch:\n" <> show x <> "\n" <> show y
+      E.Left err → SC.Failed $ "Parse error: " <> show err <> " when parsing:\n\n " <> renderEJson x <> "\n\n"
+
+main :: Eff TestEffects Unit
+main = do
+  testJsonSerialization
+  testRenderParse


### PR DESCRIPTION
This parser is ripped from the old code in SlamData, with a few bugs fixed that were caught by the new property tests (and, adjusted to support non-string keys in objects)
