### PR TITLE
more matryoshka

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,8 +15,6 @@
     "package.json"
   ],
   "dependencies": {
-    "purescript-argonaut-codecs": "^2.0.0",
-    "purescript-argonaut-core": "^2.0.1",
     "purescript-bifunctors": "^2.0.0",
     "purescript-maps": "^2.0.0",
     "purescript-matryoshka": "^0.2.0",
@@ -24,6 +22,7 @@
     "purescript-parsing": "^3.0.0",
     "purescript-precise": "^1.0.0",
     "purescript-profunctor-lenses": "^2.4.0",
-    "purescript-strongcheck": "^2.0.0"
+    "purescript-strongcheck": "^2.0.0",
+    "purescript-argonaut": "^2.0.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,6 @@
     "purescript-argonaut-codecs": "^2.0.0",
     "purescript-argonaut-core": "^2.0.1",
     "purescript-bifunctors": "^2.0.0",
-    "purescript-fixed-points": "^3.0.0",
     "purescript-maps": "^2.0.0",
     "purescript-matryoshka": "^0.2.0",
     "purescript-newtype": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
     "test": "pulp test"
   },
   "devDependencies": {
-    "pulp": "^9.0.1",
-    "purescript": "^0.10.1",
-    "purescript-psa": "^0.3.9",
-    "rimraf": "^2.5.4"
+    "pulp": "^10.0.1",
+    "purescript": "^0.10.7",
+    "purescript-psa": "^0.4.0",
+    "rimraf": "^2.6.1"
   }
 }

--- a/src/Data/Json/Extended.purs
+++ b/src/Data/Json/Extended.purs
@@ -2,10 +2,6 @@ module Data.Json.Extended
   ( module Exports
 
   , EJson(..)
-  , getEJson
-  , roll
-  , unroll
-  , head
 
   , null
   , boolean
@@ -54,8 +50,11 @@ import Data.Argonaut.Decode (class DecodeJson, decodeJson)
 import Data.Argonaut.Encode (class EncodeJson, encodeJson)
 import Data.Array as A
 import Data.Bitraversable (bitraverse)
+import Data.Bifunctor (lmap)
+import Data.Either as E
 import Data.Eq (eq1)
 import Data.Functor.Mu as Mu
+import Data.Functor.Coproduct (Coproduct)
 import Data.HugeNum as HN
 import Data.Json.Extended.Signature as Sig
 import Data.Json.Extended.Type (EJsonType)
@@ -68,7 +67,7 @@ import Data.StrMap as SM
 import Data.Traversable (for)
 import Data.Tuple as T
 
-import Matryoshka (class Corecursive, class Recursive, embed, project)
+import Matryoshka (class Corecursive, class Recursive, embed, project, cata, anaM)
 
 import Test.StrongCheck.Arbitrary as SC
 import Test.StrongCheck.Gen as Gen
@@ -86,74 +85,26 @@ instance recursiveEJson ∷ Recursive EJson Sig.EJsonF where
 instance corecursiveEJson ∷ Corecursive EJson Sig.EJsonF where
   embed = N.collect EJson embed
 
-getEJson
-  ∷ EJson
-  → Mu.Mu Sig.EJsonF
-getEJson (EJson x) =
-  x
-
-roll
-  ∷ Sig.EJsonF EJson
-  → EJson
-roll =
-  EJson
-    <<< Mu.roll
-    <<< F.map getEJson
-
-unroll
-  ∷ EJson
-  → Sig.EJsonF EJson
-unroll =
-  getEJson
-    >>> Mu.unroll
-    >>> F.map EJson
-
-head ∷ EJson → Sig.EJsonF (Mu.Mu Sig.EJsonF)
-head = Mu.unroll <<< getEJson
-
-instance eqEJson ∷ Eq EJson where
-  eq (EJson a) (EJson b) =
-    eq1 (Mu.unroll a) (Mu.unroll b)
-
-instance ordEJson ∷ Ord EJson where
-  compare (EJson a) (EJson b) =
-    compare1 (Mu.unroll a) (Mu.unroll b)
+derive newtype instance eqEJson ∷ Eq EJson
+derive newtype instance ordEJson ∷ Ord EJson
 
 instance showEJson ∷ Show EJson where
   show = renderEJson
 
 instance decodeJsonEJson ∷ DecodeJson EJson where
-  decodeJson json =
-    roll <$>
-      Sig.decodeJsonEJsonF
-        decodeJson
-        (Sig.String >>> roll)
-        json
+  decodeJson = anaM Sig.decodeJsonEJsonF
 
 -- | This is a _lossy_ encoding of EJSON to JSON; JSON only supports objects with strings
 -- as keys.
 instance encodeJsonEJson ∷ EncodeJson EJson where
-  encodeJson (EJson x) =
-    Sig.encodeJsonEJsonF
-      encodeJson
-      asKey
-      (EJson <$> Mu.unroll x)
-
-    where
-      asKey
-        ∷ EJson
-        → M.Maybe String
-      asKey (EJson y) =
-        case Mu.unroll y of
-          Sig.String k → pure k
-          _ → M.Nothing
+  encodeJson = cata Sig.encodeJsonEJsonF
 
 
 arbitraryEJsonOfSize
   ∷ Gen.Size
   → Gen.Gen EJson
 arbitraryEJsonOfSize size =
-  roll <$>
+  embed <$>
     case size of
       0 → Sig.arbitraryBaseEJsonF
       n → Sig.arbitraryEJsonF $ arbitraryEJsonOfSize (n - 1)
@@ -163,22 +114,21 @@ arbitraryJsonEncodableEJsonOfSize
   ∷ Gen.Size
   → Gen.Gen EJson
 arbitraryJsonEncodableEJsonOfSize size =
-  roll <$>
+  embed <$>
     case size of
       0 → Sig.arbitraryBaseEJsonF
       n → Sig.arbitraryEJsonFWithKeyGen keyGen $ arbitraryJsonEncodableEJsonOfSize (n - 1)
   where
     keyGen =
-      roll <<< Sig.String <$>
+      embed <<< Sig.String <$>
         SC.arbitrary
 
 renderEJson
   ∷ EJson
   → String
-renderEJson (EJson x) =
-  Sig.renderEJsonF
-    renderEJson
-    (EJson <$> Mu.unroll x)
+renderEJson =
+  cata Sig.renderEJsonF
+
 
 -- | A closed parser of SQL^2 constant expressions
 parseEJson
@@ -187,115 +137,115 @@ parseEJson
   ⇒ P.ParserT String m EJson
 parseEJson =
   Lazy.fix \f →
-    roll <$>
+    embed <$>
       Sig.parseEJsonF f
 
 
 null ∷ EJson
-null = roll Sig.Null
+null = embed Sig.Null
 
 boolean ∷ Boolean → EJson
-boolean = roll <<< Sig.Boolean
+boolean = embed <<< Sig.Boolean
 
 integer ∷ Int → EJson
-integer = roll <<< Sig.Integer
+integer = embed <<< Sig.Integer
 
 decimal ∷ HN.HugeNum → EJson
-decimal = roll <<< Sig.Decimal
+decimal = embed <<< Sig.Decimal
 
 string ∷ String → EJson
-string = roll <<< Sig.String
+string = embed <<< Sig.String
 
 timestamp ∷ String → EJson
-timestamp = roll <<< Sig.Timestamp
+timestamp = embed <<< Sig.Timestamp
 
 date ∷ String → EJson
-date = roll <<< Sig.Date
+date = embed <<< Sig.Date
 
 time ∷ String → EJson
-time = roll <<< Sig.Time
+time = embed <<< Sig.Time
 
 interval ∷ String → EJson
-interval = roll <<< Sig.Interval
+interval = embed <<< Sig.Interval
 
 objectId ∷ String → EJson
-objectId = roll <<< Sig.ObjectId
+objectId = embed <<< Sig.ObjectId
 
 array ∷ Array EJson → EJson
-array = roll <<< Sig.Array
+array = embed <<< Sig.Array
 
 map ∷ Map.Map EJson EJson → EJson
-map = roll <<< Sig.Map <<< A.fromFoldable <<< Map.toList
+map = embed <<< Sig.Map <<< A.fromFoldable <<< Map.toList
 
 map' ∷ SM.StrMap EJson → EJson
-map' = roll <<< Sig.Map <<< F.map go <<< A.fromFoldable <<< SM.toList
+map' = embed <<< Sig.Map <<< F.map go <<< A.fromFoldable <<< SM.toList
   where
     go (T.Tuple a b) = T.Tuple (string a) b
 
 getType ∷ EJson → EJsonType
-getType = Sig.getType <<< head
+getType = Sig.getType <<< project
 
 _Null ∷ Prism' EJson Unit
-_Null = prism' (const null) $ head >>> case _ of
+_Null = prism' (const null) $ project >>> case _ of
   Sig.Null → M.Just unit
   _ → M.Nothing
 
 _String ∷ Prism' EJson String
-_String = prism' string $ head >>> case _ of
+_String = prism' string $ project >>> case _ of
   Sig.String s → M.Just s
   _ → M.Nothing
 
 _Boolean ∷ Prism' EJson Boolean
-_Boolean = prism' boolean $ head >>> case _ of
+_Boolean = prism' boolean $ project >>> case _ of
   Sig.Boolean b → M.Just b
   _ → M.Nothing
 
 _Integer ∷ Prism' EJson Int
-_Integer = prism' integer $ head >>> case _ of
+_Integer = prism' integer $ project >>> case _ of
   Sig.Integer i → M.Just i
   _ → M.Nothing
 
 _Decimal ∷ Prism' EJson HN.HugeNum
-_Decimal = prism' decimal $ head >>> case _ of
+_Decimal = prism' decimal $ project >>> case _ of
   Sig.Decimal d → M.Just d
   _ → M.Nothing
 
 _Timestamp ∷ Prism' EJson String
-_Timestamp = prism' timestamp $ head >>> case _ of
+_Timestamp = prism' timestamp $ project >>> case _ of
   Sig.Timestamp t → M.Just t
   _ → M.Nothing
 
 _Date ∷ Prism' EJson String
-_Date = prism' date $ head >>> case _ of
+_Date = prism' date $ project >>> case _ of
   Sig.Date d → M.Just d
   _ → M.Nothing
 
 _Time ∷ Prism' EJson String
-_Time = prism' time $ head >>> case _ of
+_Time = prism' time $ project >>> case _ of
   Sig.Time t → M.Just t
   _ → M.Nothing
 
 _Interval ∷ Prism' EJson String
-_Interval = prism' interval $ head >>> case _ of
+_Interval = prism' interval $ project >>> case _ of
   Sig.Interval i → M.Just i
   _ → M.Nothing
 
 _ObjectId ∷ Prism' EJson String
-_ObjectId = prism' objectId $ head >>> case _ of
+_ObjectId = prism' objectId $ project >>> case _ of
   Sig.ObjectId id → M.Just id
   _ → M.Nothing
 
 _Array ∷ Prism' EJson (Array EJson)
-_Array = prism' array $ unroll >>> case _ of
+_Array = prism' array $ project >>> case _ of
   Sig.Array xs → M.Just xs
   _ → M.Nothing
 
 _Map ∷ Prism' EJson (Map.Map EJson EJson)
-_Map = prism' map $ unroll >>> case _ of
+_Map = prism' map $ project >>> case _ of
   Sig.Map kvs → M.Just $ Map.fromFoldable kvs
   _ → M.Nothing
 
 _Map' ∷ Prism' EJson (SM.StrMap EJson)
-_Map' = prism' map' $ unroll >>> case _ of
+_Map' = prism' map' $ project >>> case _ of
   Sig.Map kvs → SM.fromFoldable <$> for kvs (bitraverse (preview _String) pure)
   _ → M.Nothing

--- a/src/Data/Json/Extended.purs
+++ b/src/Data/Json/Extended.purs
@@ -49,7 +49,6 @@ import Control.Lazy as Lazy
 import Data.Argonaut as JS
 import Data.Array as A
 import Data.Bitraversable (bitraverse)
-import Data.Bifunctor (lmap)
 import Data.Either as E
 import Data.Functor.Mu as Mu
 import Data.HugeNum as HN
@@ -58,13 +57,11 @@ import Data.Json.Extended.Type (EJsonType)
 import Data.Lens (Prism', preview, prism')
 import Data.Map as Map
 import Data.Maybe as M
-import Data.Newtype as N
-import Data.Ord (compare1)
 import Data.StrMap as SM
 import Data.Traversable (for)
 import Data.Tuple as T
 
-import Matryoshka (class Corecursive, class Recursive, embed, project, cata, anaM)
+import Matryoshka (embed, project, cata, anaM)
 
 import Test.StrongCheck.Arbitrary as SC
 import Test.StrongCheck.Gen as Gen

--- a/src/Data/Json/Extended/Cursor.purs
+++ b/src/Data/Json/Extended/Cursor.purs
@@ -12,6 +12,8 @@ import Data.Maybe (Maybe(..), maybe)
 import Data.Ord (class Ord1)
 import Data.Tuple (Tuple(..), lookup)
 
+import Data.Json.Extended (renderEJson)
+
 import Matryoshka (Algebra, cata, project, embed)
 
 -- | A cursor to a location in an EJson value.
@@ -47,15 +49,14 @@ derive instance ordCursor ∷ Ord a ⇒ Ord (CursorF a)
 
 instance eq1CursorF ∷ Eq1 CursorF where
   eq1 = eq
-
 instance ord1CursorF ∷ Ord1 CursorF where
   compare1 = compare
 
-instance showCursorF ∷ Show a => Show (CursorF a) where
-  show = case _ of
-    All → "All"
-    AtKey k a → "(AtKey " <> show k <> " " <> show a <> ")"
-    AtIndex i a → "(AtIndex " <> show i <> " " <> show a <> ")"
+renderEJsonCursor ∷ Cursor → String
+renderEJsonCursor = cata case _ of
+  All → "All"
+  AtKey ejson a → "(AtKey " <> renderEJson ejson <> " " <> a <> ")"
+  AtIndex i a → "(AtIndex " <> show i <> " " <> a <> ")"
 
 -- | Peels off one layer of a cursor, if possible. The resulting tuple contains
 -- | the current step (made relative), and the remainder of the cursor.
@@ -76,7 +77,7 @@ peel c = case project c of
 get ∷ Cursor → EJson → Maybe EJson
 get = cata go
   where
-  go :: Algebra CursorF (EJson -> Maybe EJson)
+  go ∷ Algebra CursorF (EJson → Maybe EJson)
   go = case _ of
     All → Just
     AtKey k prior → getKey k <=< prior

--- a/src/Data/Json/Extended/Cursor.purs
+++ b/src/Data/Json/Extended/Cursor.purs
@@ -5,14 +5,14 @@ import Prelude
 import Data.Array as A
 import Data.Bifunctor (lmap)
 import Data.Eq (class Eq1)
-import Data.Functor.Mu (Mu, roll, unroll)
+import Data.Functor.Mu (Mu)
 import Data.Json.Extended (EJson)
 import Data.Json.Extended as EJ
 import Data.Maybe (Maybe(..), maybe)
 import Data.Ord (class Ord1)
 import Data.Tuple (Tuple(..), lookup)
 
-import Matryoshka (Algebra, cata)
+import Matryoshka (Algebra, cata, project, embed)
 
 -- | A cursor to a location in an EJson value.
 -- |
@@ -27,13 +27,13 @@ import Matryoshka (Algebra, cata)
 type Cursor = Mu CursorF
 
 all ∷ Cursor
-all = roll All
+all = embed All
 
 atKey ∷ EJ.EJson → Cursor → Cursor
-atKey k = roll <<< AtKey k
+atKey k = embed <<< AtKey k
 
 atIndex ∷ Int → Cursor → Cursor
-atIndex i = roll <<< AtIndex i
+atIndex i = embed <<< AtIndex i
 
 -- | The possible steps in a cursor.
 data CursorF a
@@ -66,7 +66,7 @@ instance showCursorF ∷ Show a => Show (CursorF a) where
 -- | peel all == Nothing
 -- | ```
 peel ∷ Cursor → Maybe (Tuple Cursor Cursor)
-peel c = case unroll c of
+peel c = case project c of
   All → Nothing
   AtKey k rest → Just $ Tuple (atKey k all) rest
   AtIndex i rest → Just $ Tuple (atIndex i all) rest
@@ -85,7 +85,7 @@ get = cata go
 -- | Takes a cursor and attempts to set an EJson value within a larger EJson
 -- | value if the value the cursor points at exists.
 set ∷ Cursor → EJson → EJson → EJson
-set cur x v = case lmap unroll <$> peel cur of
+set cur x v = case lmap project <$> peel cur of
   Nothing → x
   Just (Tuple All _) → x
   Just (Tuple (AtKey k _) path) → maybe v (setKey k x) $ get path v
@@ -100,8 +100,8 @@ set cur x v = case lmap unroll <$> peel cur of
 -- | getKey (EJ.string "foo") (EJ.boolean false) == Nothing
 -- | ```
 getKey ∷ EJ.EJson → EJ.EJson → Maybe EJ.EJson
-getKey k v = case EJ.head v of
-  EJ.Map fields → EJ.EJson <$> lookup (EJ.getEJson k) fields
+getKey k v = case project v of
+  EJ.Map fields → lookup k fields
   _ → Nothing
 
 -- | For a given key, attempts to set a new value for it in an EJson Map. If the
@@ -115,9 +115,9 @@ getKey k v = case EJ.head v of
 -- | setKey (EJ.string "foo") (EJ.boolean true) (EJ.string "not-a-map") == EJ.string "not-a-map"
 -- | ```
 setKey ∷ EJ.EJson → EJ.EJson → EJ.EJson → EJ.EJson
-setKey (EJ.EJson k) (EJ.EJson x) v = case EJ.head v of
+setKey k x v = case project v of
   EJ.Map fields →
-    EJ.EJson <<< roll <<< EJ.Map $ map
+    embed <<< EJ.Map $ map
       (\(kv@(Tuple k' v)) → if k == k' then Tuple k x else kv) fields
   _ → v
 
@@ -130,8 +130,8 @@ setKey (EJ.EJson k) (EJ.EJson x) v = case EJ.head v of
 -- | getIndex 0 (EJ.boolean false) == Nothing
 -- | ```
 getIndex ∷ Int → EJ.EJson → Maybe EJ.EJson
-getIndex i v = case EJ.head v of
-  EJ.Array items → EJ.EJson <$> A.index items i
+getIndex i v = case project v of
+  EJ.Array items → A.index items i
   _ → Nothing
 
 -- | For a given index, attempts to set a new value for it in an EJson Array. If
@@ -145,7 +145,7 @@ getIndex i v = case EJ.head v of
 -- | setIndex 0 (EJ.boolean true) (EJ.string "not-an-array") == EJ.string "not-an-array"
 -- | ```
 setIndex ∷ Int → EJ.EJson → EJ.EJson → EJ.EJson
-setIndex i (EJ.EJson x) v = case EJ.head v of
+setIndex i x v = case project v of
   EJ.Array items →
-    maybe v (EJ.EJson <<< roll <<< EJ.Array) $ A.updateAt i x items
+    maybe v (embed <<< EJ.Array) $ A.updateAt i x items
   _ → v

--- a/src/Data/Json/Extended/Cursor.purs
+++ b/src/Data/Json/Extended/Cursor.purs
@@ -6,13 +6,11 @@ import Data.Array as A
 import Data.Bifunctor (lmap)
 import Data.Eq (class Eq1)
 import Data.Functor.Mu (Mu)
-import Data.Json.Extended (EJson)
+import Data.Json.Extended (EJson, renderEJson)
 import Data.Json.Extended as EJ
 import Data.Maybe (Maybe(..), maybe)
 import Data.Ord (class Ord1)
 import Data.Tuple (Tuple(..), lookup)
-
-import Data.Json.Extended (renderEJson)
 
 import Matryoshka (Algebra, cata, project, embed)
 
@@ -31,7 +29,7 @@ type Cursor = Mu CursorF
 all ∷ Cursor
 all = embed All
 
-atKey ∷ EJ.EJson → Cursor → Cursor
+atKey ∷ EJson → Cursor → Cursor
 atKey k = embed <<< AtKey k
 
 atIndex ∷ Int → Cursor → Cursor

--- a/src/Data/Json/Extended/Signature/Core.purs
+++ b/src/Data/Json/Extended/Signature/Core.purs
@@ -11,9 +11,8 @@ import Data.Foldable as F
 import Data.Traversable as T
 import Data.HugeNum as HN
 import Data.Int as Int
-import Data.Json.Extended.Type as T
+import Data.Json.Extended.Type as JT
 import Data.List as L
-import Data.Map as Map
 import Data.Monoid (mempty)
 import Data.Ord (class Ord1)
 import Data.Tuple (Tuple(..))
@@ -132,17 +131,17 @@ derive instance ordEJsonF ∷ Ord a ⇒ Ord (EJsonF a)
 instance ord1EJsonF ∷ Ord1 EJsonF where
   compare1 = compare
 
-getType ∷ ∀ a. EJsonF a → T.EJsonType
+getType ∷ ∀ a. EJsonF a → JT.EJsonType
 getType = case _ of
-  Null → T.Null
-  String _ → T.String
-  Boolean _ → T.Boolean
-  Integer _ → T.Integer
-  Decimal _ → T.Decimal
-  Timestamp _ → T.Timestamp
-  Date _ → T.Date
-  Time _ → T.Time
-  Interval _ → T.Interval
-  ObjectId _ → T.ObjectId
-  Array _ → T.Array
-  Map _ → T.Map
+  Null → JT.Null
+  String _ → JT.String
+  Boolean _ → JT.Boolean
+  Integer _ → JT.Integer
+  Decimal _ → JT.Decimal
+  Timestamp _ → JT.Timestamp
+  Date _ → JT.Date
+  Time _ → JT.Time
+  Interval _ → JT.Interval
+  ObjectId _ → JT.ObjectId
+  Array _ → JT.Array
+  Map _ → JT.Map

--- a/src/Data/Json/Extended/Signature/Json.purs
+++ b/src/Data/Json/Extended/Signature/Json.purs
@@ -3,12 +3,8 @@ module Data.Json.Extended.Signature.Json where
 import Prelude
 
 import Control.Alt ((<|>))
-import Control.Bind ((>=>))
 
-import Data.Bifunctor (lmap, bimap)
-import Data.Eq (class Eq1)
-import Data.Ord (class Ord1)
-import Data.Functor.Coproduct (Coproduct(..), coproduct, right, left)
+import Data.Bifunctor (lmap)
 import Data.Argonaut.Core as JS
 import Data.Argonaut.Decode (class DecodeJson, decodeJson, (.?))
 import Data.Argonaut.Encode (encodeJson)
@@ -16,7 +12,6 @@ import Data.Array as A
 import Data.Either as E
 import Data.HugeNum as HN
 import Data.Int as Int
-import Data.Newtype (class Newtype, unwrap, wrap)
 import Data.Json.Extended.Signature.Core (EJsonF(..))
 import Data.Maybe as M
 import Data.StrMap as SM

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -6,13 +6,11 @@ import Control.Monad.Eff.Exception (EXCEPTION)
 import Control.Monad.Eff.Random (RANDOM)
 import Control.Monad.Eff.Console (CONSOLE)
 
-import Data.Argonaut.Decode (decodeJson)
-import Data.Argonaut.Encode (encodeJson)
 import Data.Either as E
 import Data.Maybe (Maybe(..))
 import Data.StrMap as SM
 import Data.Tuple (Tuple(..))
-import Data.Json.Extended (EJson, arbitraryJsonEncodableEJsonOfSize, arbitraryEJsonOfSize, renderEJson, parseEJson)
+import Data.Json.Extended (EJson, arbitraryJsonEncodableEJsonOfSize, arbitraryEJsonOfSize, renderEJson, parseEJson, decodeEJson, encodeEJson)
 import Data.Json.Extended as EJ
 import Data.Json.Extended.Cursor as EJC
 
@@ -39,44 +37,44 @@ instance arbitraryArbEJson ∷ SCA.Arbitrary ArbEJson where
 testJsonSerialization ∷ Eff TestEffects Unit
 testJsonSerialization =
   SC.quickCheck \(ArbJsonEncodableEJson x) →
-    case decodeJson (encodeJson x) of
-      E.Right y → x == y SC.<?> "Mismatch:\n" <> show x <> "\n" <> show y
+    case decodeEJson (encodeEJson x) of
+      E.Right y → x == y SC.<?> "Mismatch:\n" <> renderEJson x <> "\n" <> renderEJson y
       E.Left err → SC.Failed $ "Parse error: " <> err
 
 testRenderParse ∷ Eff TestEffects Unit
 testRenderParse =
   SC.quickCheck \(ArbEJson x) →
     case P.runParser (renderEJson x) parseEJson of
-      E.Right y → x == y SC.<?> "Mismatch:\n" <> show x <> "\n" <> show y
+      E.Right y → x == y SC.<?> "Mismatch:\n" <> renderEJson x <> "\n" <> renderEJson y
       E.Left err → SC.Failed $ "Parse error: " <> show err <> " when parsing:\n\n " <> renderEJson x <> "\n\n"
 
 testCursorExamples ∷ Eff TestEffects Unit
 testCursorExamples = do
-  assertEq
+  assertMbTplEq
     (EJC.peel (EJC.atKey (EJ.string "foo") $ EJC.atIndex 0 EJC.all))
     (Just (Tuple (EJC.atKey (EJ.string "foo") EJC.all) (EJC.atIndex 0 EJC.all)))
-  assertEq
+  assertMbTplEq
     (EJC.peel (EJC.atIndex 0 EJC.all))
     (Just (Tuple (EJC.atIndex 0 EJC.all) EJC.all))
-  assertEq
+  assertMbTplEq
     (EJC.peel EJC.all)
     Nothing
-  assertEq
+  assertMbEq
     (EJC.getKey (EJ.string "foo") (EJ.map' $ EJ.string <$> SM.fromFoldable [Tuple "foo" "bar"]))
     (Just (EJ.string "bar"))
-  assertEq
+  assertMbEq
     (EJC.getKey (EJ.string "foo") (EJ.map' $ EJ.string <$> SM.fromFoldable [Tuple "key" "value"]))
     Nothing
-  assertEq
+  assertMbEq
     (EJC.getKey (EJ.string "foo") (EJ.boolean false))
     Nothing
-  assertEq
+  assertMbEq
     (EJC.getIndex 0 (EJ.array $ EJ.string <$> ["foo"]))
     (Just (EJ.string "foo"))
-  assertEq
+  assertMbEq
     (EJC.getIndex 1 (EJ.array $ EJ.string <$> ["foo"]))
     Nothing
-  assertEq
+  assertMbEq
     (EJC.getIndex 0 (EJ.boolean false))
     Nothing
   let map = EJ.map' $ EJ.string <$> SM.fromFoldable [Tuple "foo" "bar"]
@@ -100,8 +98,24 @@ testCursorExamples = do
     (EJC.setIndex 0 (EJ.boolean true) (EJ.string "not-an-array"))
     (EJ.string "not-an-array")
   where
-  assertEq ∷ ∀ a. (Show a, Eq a) ⇒ a → a → Eff TestEffects Unit
-  assertEq x y = SC.assert $ SC.assertEq x y
+  assertMbTplEq
+    ∷ Maybe (Tuple EJC.Cursor EJC.Cursor)
+    → Maybe (Tuple EJC.Cursor EJC.Cursor)
+    → Eff TestEffects Unit
+  assertMbTplEq x y =
+    SC.assert
+    $ SC.assertEq
+        (map (\(Tuple a b) → "Tuple " <> EJC.renderEJsonCursor a <> " " <> EJC.renderEJsonCursor b) x)
+        (map (\(Tuple a b) → "Tuple " <> EJC.renderEJsonCursor a <> " " <> EJC.renderEJsonCursor b) y)
+
+  assertMbEq ∷ Maybe EJson → Maybe EJson → Eff TestEffects Unit
+  assertMbEq x y = SC.assert $ SC.assertEq (map renderEJson x) (map renderEJson y)
+
+  assertEq ∷ EJson → EJson → Eff TestEffects Unit
+  assertEq x y = SC.assert $ x == y SC.<?> msg
+    where
+    msg = renderEJson x <> " /= " <> renderEJson y
+
 
 main :: Eff TestEffects Unit
 main = do

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -9,9 +9,9 @@ import Control.Monad.Eff.Console (CONSOLE)
 import Data.Argonaut.Decode (decodeJson)
 import Data.Argonaut.Encode (encodeJson)
 import Data.Either as E
-import Data.Maybe
+import Data.Maybe (Maybe(..))
 import Data.StrMap as SM
-import Data.Tuple
+import Data.Tuple (Tuple(..))
 import Data.Json.Extended (EJson, arbitraryJsonEncodableEJsonOfSize, arbitraryEJsonOfSize, renderEJson, parseEJson)
 import Data.Json.Extended as EJ
 import Data.Json.Extended.Cursor as EJC


### PR DESCRIPTION
@garyb Please take a look 

I've removed `roll`, `unroll` and other custom stuff in favour of using Matryoshka's combinators. Honestly I'd change `parseEJson` too, but I'm not sure if this is good idea. 

As far as I understand `Traversable` instance is used only in meaning: `EJsonF (List foo) -> List (EJsonF foo)`. Is it correct? 

@jdegoes  Can we use `Set (Tuple a a)` for `Map`? 