### PR TITLE
Fix `Ord` / `Ord1` by restoring original `Ord1` instance

### DIFF
--- a/src/Data/Json/Extended.purs
+++ b/src/Data/Json/Extended.purs
@@ -146,10 +146,10 @@ array ∷ ∀ t. Corecursive t Sig.EJsonF ⇒ Array t → t
 array = embed <<< Sig.Array
 
 map ∷ ∀ t. Corecursive t Sig.EJsonF ⇒ Map.Map t t → t
-map = embed <<< Sig.Map <<< A.fromFoldable <<< Map.toList
+map = embed <<< Sig.Map <<< Sig.EJsonMap <<< A.fromFoldable <<< Map.toList
 
 map' ∷ ∀ t. Corecursive t Sig.EJsonF ⇒ SM.StrMap t → t
-map' = embed <<< Sig.Map <<< F.map go <<< A.fromFoldable <<< SM.toList
+map' = embed <<< Sig.Map <<< Sig.EJsonMap <<< F.map go <<< A.fromFoldable <<< SM.toList
   where
     go (T.Tuple a b) = T.Tuple (string a) b
 
@@ -213,10 +213,10 @@ _Array = prism' array $ project >>> case _ of
 
 _Map ∷ ∀ t. (Corecursive t Sig.EJsonF, Recursive t Sig.EJsonF, Ord t) ⇒ Prism' t (Map.Map t t)
 _Map = prism' map $ project >>> case _ of
-  Sig.Map kvs → M.Just $ Map.fromFoldable kvs
+  Sig.Map (Sig.EJsonMap kvs) → M.Just $ Map.fromFoldable kvs
   _ → M.Nothing
 
 _Map' ∷ ∀ t. (Corecursive t Sig.EJsonF, Recursive t Sig.EJsonF) ⇒ Prism' t (SM.StrMap t)
 _Map' = prism' map' $ project >>> case _ of
-  Sig.Map kvs → SM.fromFoldable <$> for kvs (bitraverse (preview _String) pure)
+  Sig.Map (Sig.EJsonMap kvs) → SM.fromFoldable <$> for kvs (bitraverse (preview _String) pure)
   _ → M.Nothing

--- a/src/Data/Json/Extended/Cursor.purs
+++ b/src/Data/Json/Extended/Cursor.purs
@@ -105,7 +105,7 @@ set cur x v = case lmap project <$> peel cur of
 -- | ```
 getKey ∷ EJ.EJson → EJ.EJson → Maybe EJ.EJson
 getKey k v = case project v of
-  EJ.Map fields → lookup k fields
+  EJ.Map (EJ.EJsonMap fields) → lookup k fields
   _ → Nothing
 
 -- | For a given key, attempts to set a new value for it in an EJson Map. If the
@@ -120,8 +120,8 @@ getKey k v = case project v of
 -- | ```
 setKey ∷ EJ.EJson → EJ.EJson → EJ.EJson → EJ.EJson
 setKey k x v = case project v of
-  EJ.Map fields →
-    embed <<< EJ.Map $ map
+  EJ.Map (EJ.EJsonMap fields) →
+    embed <<< EJ.Map <<< EJ.EJsonMap $ map
       (\(kv@(Tuple k' v)) → if k == k' then Tuple k x else kv) fields
   _ → v
 

--- a/src/Data/Json/Extended/Signature/Gen.purs
+++ b/src/Data/Json/Extended/Signature/Gen.purs
@@ -10,7 +10,7 @@ import Data.Array as A
 import Data.DateTime as DT
 import Data.Enum (toEnum)
 import Data.HugeNum as HN
-import Data.Json.Extended.Signature.Core (EJsonF(..))
+import Data.Json.Extended.Signature.Core (EJsonF(..), EJsonMap(..))
 import Data.Maybe (fromMaybe)
 import Data.Tuple as T
 
@@ -42,7 +42,7 @@ arbitraryEJsonFWithKeyGen keyGen rec =
   Gen.oneOf (pure Null)
     [ arbitraryBaseEJsonF
     , Array <$> Gen.arrayOf rec
-    , Map <$> do
+    , Map <<< EJsonMap <$> do
         keys ← distinctArrayOf keyGen
         vals ← Gen.vectorOf (A.length keys) rec
         pure $ A.zip keys vals

--- a/src/Data/Json/Extended/Signature/Json.purs
+++ b/src/Data/Json/Extended/Signature/Json.purs
@@ -13,7 +13,7 @@ import Data.DateTime as DT
 import Data.Either as E
 import Data.HugeNum as HN
 import Data.Int as Int
-import Data.Json.Extended.Signature.Core (EJsonF(..))
+import Data.Json.Extended.Signature.Core (EJsonF(..), EJsonMap(..))
 import Data.Json.Extended.Signature.Parse (parseDate, parseTime, parseTimestamp)
 import Data.Json.Extended.Signature.Render (renderDate, renderTime, renderTimestamp)
 import Data.Maybe as M
@@ -37,7 +37,7 @@ encodeJsonEJsonF = case _ of
   Interval str → JS.jsonSingletonObject "$interval" $ encodeJson str
   ObjectId str → JS.jsonSingletonObject "$oid" $ encodeJson str
   Array xs → encodeJson xs
-  Map xs → JS.jsonSingletonObject "$obj" $ encodeJson $ asStrMap xs
+  Map (EJsonMap xs) → JS.jsonSingletonObject "$obj" $ encodeJson $ asStrMap xs
   where
   tuple
     ∷ T.Tuple JS.Json JS.Json
@@ -89,6 +89,7 @@ decodeJsonEJsonF =
     → EJsonF JS.Json
   strMapObject =
     Map
+    <<< EJsonMap
     <<< A.fromFoldable
     <<< map (lmap encodeJson)
     <<< SM.toList

--- a/src/Data/Json/Extended/Signature/Render.purs
+++ b/src/Data/Json/Extended/Signature/Render.purs
@@ -12,7 +12,7 @@ import Data.Either (fromRight)
 import Data.Enum (class BoundedEnum, fromEnum)
 import Data.Foldable as F
 import Data.HugeNum as HN
-import Data.Json.Extended.Signature.Core (EJsonF(..))
+import Data.Json.Extended.Signature.Core (EJsonF(..), EJsonMap(..))
 import Data.String.Regex as RX
 import Data.String.Regex.Flags as RXF
 import Data.Tuple as T
@@ -34,7 +34,7 @@ renderEJsonF = case _ of
   Interval str → tagged "INTERVAL" str
   ObjectId str → tagged "OID" str
   Array ds → squares $ commaSep ds
-  Map ds → braces $ renderPairs ds
+  Map (EJsonMap ds) → braces $ renderPairs ds
 
 tagged ∷ String → String → String
 tagged tag str =


### PR DESCRIPTION
@cryogenian We done messed up by deriving `Ord` in 59347625e77399541c2ef141d864f0ebc2826d27 - that's the reason for https://github.com/slamdata/slamdata/pull/1504#issuecomment-286280013

I've added comments so we don't do it again in the future :smile: